### PR TITLE
feat: 포스터 검색 API #5

### DIFF
--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -201,6 +201,21 @@ public class PosterService {
                 });
     }
 
+    public Page<PosterDto> searchPosters(String keyword, int page, int size) {
+        // 페이징 조건 추가
+        Pageable pageable = createPageable(page, size);
+
+        // Member 찾기
+        Member member = memberService.findMemberByEmail();
+
+        // 포스터의 제목 또는 이벤트 설명에 해당 키워드가 포함되어 있는 포스터들만 조회
+        return posterRepository.findByTitleContainingOrEventDescriptionContaining(keyword, keyword, pageable)
+                .map(poster -> {
+                    boolean isLike = posterLikeRepository.findByMemberIdAndPosterId(member.getMemberId(), poster.getPosterId()).isPresent();
+                    return new PosterDto(poster, isLike);
+                });
+    }
+
     // 매일 정오마다 실행
     @Scheduled(cron = "0 0 12 * * ?")
     @Transactional

--- a/src/main/java/fete/be/domain/poster/application/dto/request/SearchPostersRequest.java
+++ b/src/main/java/fete/be/domain/poster/application/dto/request/SearchPostersRequest.java
@@ -1,0 +1,10 @@
+package fete.be.domain.poster.application.dto.request;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class SearchPostersRequest {
+    private String keyword;  // 검색어
+}

--- a/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
+++ b/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
@@ -19,6 +19,8 @@ public interface PosterRepository extends JpaRepository<Poster, Long> {
 
     Page<Poster> findByPosterIdIn(List<Long> posterIds, Pageable pageable);
 
+    Page<Poster> findByTitleContainingOrEventDescriptionContaining(String keyword1, String keyword2, Pageable pageable);
+
     Optional<Poster> findByStatusAndPosterId(Status status, Long posterId);
 
     @Query("select p from Poster p where p.status = 'ACTIVE' and p.event.endDate < :now")

--- a/src/main/java/fete/be/domain/poster/web/PosterController.java
+++ b/src/main/java/fete/be/domain/poster/web/PosterController.java
@@ -4,6 +4,7 @@ import fete.be.domain.member.application.MemberService;
 import fete.be.domain.member.persistence.Member;
 import fete.be.domain.poster.application.PosterService;
 import fete.be.domain.poster.application.dto.request.ModifyPosterRequest;
+import fete.be.domain.poster.application.dto.request.SearchPostersRequest;
 import fete.be.domain.poster.application.dto.request.WritePosterRequest;
 import fete.be.domain.poster.application.dto.response.GetPostersResponse;
 import fete.be.domain.poster.application.dto.response.PosterDto;
@@ -220,6 +221,39 @@ public class PosterController {
             return new ApiResponse<>(ResponseMessage.LIKE_GET_POSTER_SUCCESS.getCode(), ResponseMessage.LIKE_GET_POSTER_SUCCESS.getMessage(), result);
         } catch (IllegalArgumentException e) {
             return new ApiResponse<>(ResponseMessage.LIKE_GET_POSTER_FAILURE.getCode(), e.getMessage());
+        }
+    }
+
+
+    /**
+     * 포스터 검색 API
+     * - 키워드로 포스터 제목, 이벤트 설명 필드를 검색하는 API입니다.
+     *
+     * @param SearchPostersRequest request
+     * @param int page
+     * @param int size
+     * @return ApiResponse<GetPostersResponse>
+     */
+    @PostMapping("/search")
+    public ApiResponse<GetPostersResponse> searchPosters(
+            @RequestBody SearchPostersRequest request,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        try {
+            log.info("SearchPosters request: request={}", request);
+            Logging.time();
+
+            // 키워드 추출
+            String keyword = request.getKeyword();
+
+            // 제목 또는 설명에 키워드가 포함되어 있는 포스터들 조회
+            List<PosterDto> searchedPosters = posterService.searchPosters(keyword, page, size).getContent();
+            GetPostersResponse result = new GetPostersResponse(searchedPosters);
+
+            return new ApiResponse<>(ResponseMessage.POSTER_SEARCH_SUCCESS.getCode(), ResponseMessage.POSTER_SEARCH_SUCCESS.getMessage(), result);
+        } catch (IllegalArgumentException e) {
+            return new ApiResponse<>(ResponseMessage.POSTER_SEARCH_FAILURE.getCode(), e.getMessage());
         }
     }
 }

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -44,6 +44,8 @@ public enum ResponseMessage {
     POSTER_INVALID_POSTER(1002, "해당 포스터가 존재하지 않습니다."),
     POSTER_INVALID_USER(1003, "해당 포스터의 작성자가 아닙니다."),
     POSTER_INVALID_EVENT(1004, "해당 이벤트가 존재하지 않습니다."),
+    POSTER_SEARCH_SUCCESS(1005, "포스터 검색에 성공하였습니다."),
+    POSTER_SEARCH_FAILURE(1006, "포스터 검색에 실패하였습니다."),
 
     // EVENT
     EVENT_QR_SUCCESS(1100, "QR 코드 발급에 성공하였습니다."),


### PR DESCRIPTION
PosterController
- searchPosters: 포스터 검색 API
- SearchPostersRequest: 해당 API의 요청 DTO
- ResponseMessage: POSTER 관련 코드 추가

PosterService
- searchPosters: 키워드로 포스터 제목 및 이벤트 설명을 검색하여 조회하는 메서드

PosterRepository
- findByTitleContainingOrEventDescriptionContaining: 포스터 title과 이벤트 description 필드에서 전달 받은 keyword를 검색