### PR TITLE
feat: 관리자 - 아티스트 프로필 등록 API #5 #7

### DIFF
--- a/src/main/java/fete/be/domain/admin/application/dto/request/SetArtistImageUrlsRequest.java
+++ b/src/main/java/fete/be/domain/admin/application/dto/request/SetArtistImageUrlsRequest.java
@@ -1,0 +1,12 @@
+package fete.be.domain.admin.application.dto.request;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class SetArtistImageUrlsRequest {
+    List<String> imageUrls;
+}

--- a/src/main/java/fete/be/domain/event/persistence/Artist.java
+++ b/src/main/java/fete/be/domain/event/persistence/Artist.java
@@ -3,6 +3,8 @@ package fete.be.domain.event.persistence;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.util.List;
+
 @Entity
 @Getter
 public class Artist {
@@ -33,5 +35,14 @@ public class Artist {
         artist.event = event;
 
         return artist;
+    }
+
+    // 프로필 이미지 등록 메서드 (관리자용)
+    public static void updateInfoUrls(List<Artist> artists, List<String> imageUrls) {
+        int artistNumber = 0;
+        for (Artist artist : artists) {
+            artist.imageUrl = imageUrls.get(artistNumber);
+            artistNumber += 1;
+        }
     }
 }

--- a/src/main/java/fete/be/domain/event/persistence/Event.java
+++ b/src/main/java/fete/be/domain/event/persistence/Event.java
@@ -79,7 +79,6 @@ public class Event {
     private List<Payment> payments = new ArrayList<>();  // 결제 상태 리스트
 
 
-
     // 생성 메서드
     public static Event createEvent(Poster poster, EventDto request) {
         Event event = new Event();

--- a/src/main/java/fete/be/domain/poster/exception/ProfileImageCountMismatchException.java
+++ b/src/main/java/fete/be/domain/poster/exception/ProfileImageCountMismatchException.java
@@ -1,0 +1,7 @@
+package fete.be.domain.poster.exception;
+
+public class ProfileImageCountMismatchException extends RuntimeException{
+    public ProfileImageCountMismatchException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -103,6 +103,9 @@ public enum ResponseMessage {
     ADMIN_DELETE_CATEGORY_FAIL(7027, "카테고리 삭제가 실패하였습니다."),
     ADMIN_ALL_NOTIFICATION_SUCCESS(7028, "전체 푸시 알림 전송이 성공하였습니다."),
     ADMIN_NOTIFICATION_FAILURE(7029, "푸시 알림 전송이 실패하였습니다."),
+    ADMIN_REGISTER_ARTIST_PROFILE_SUCCESS(7030, "아티스트 프로필 이미지 등록이 성공하였습니다."),
+    ADMIN_REGISTER_ARTIST_PROFILE_FAIL(7031, "아티스트 프로필 이미지 등록이 실패하였습니다."),
+    ADMIN_INVALID_ARTIST_PROFILE_COUNT(7032, "아티스트 프로필 이미지 개수가 일치하지 않습니다."),
 
     // BANNER
     BANNER_GET_BANNERS(1400, "배너 전체 조회에 성공하였습니다."),


### PR DESCRIPTION
AdminController
- setArtistImageUrls: 관리자의 아티스트 프로필 이미지 등록 API
- SetArtistImageUrlsRequest: 등록할 이미지 URL 리스트 DTO
- ResponseMessage: ADMIN 관련 코드 추가
- ProfileImageCountMismatchException: 아티스트의 수와 전달된 이미지 리스트의 수가 일치하지 않을 경우에 대한 Exception

Artist
- updateInfoUrls: 프로필 이미지 등록 메서드

PosterService
- setArtistImageUrls: 관리자용 아티스트 프로필 이미지 등록하는 메서드