### PR TITLE
feat: 여러 티켓 동시 취소 #10

### DIFF
--- a/src/main/java/fete/be/domain/payment/application/dto/request/TossCancelRequest.java
+++ b/src/main/java/fete/be/domain/payment/application/dto/request/TossCancelRequest.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TossCancelRequest {
-    private String cancelReason;  // 취소 사유 (필수)
-    @Nullable
-    private int cancelAmount;  // 부분 취소 금액 (선택)
+    private String cancelReason;  // 취소 사유
+    private int cancelAmount;  // 부분 취소 금액
 }

--- a/src/main/java/fete/be/domain/payment/exception/InvalidCancelReasonException.java
+++ b/src/main/java/fete/be/domain/payment/exception/InvalidCancelReasonException.java
@@ -1,0 +1,7 @@
+package fete.be.domain.payment.exception;
+
+public class InvalidCancelReasonException extends RuntimeException {
+    public InvalidCancelReasonException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fete/be/domain/ticket/application/dto/request/CancelTicketsRequest.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/request/CancelTicketsRequest.java
@@ -1,0 +1,13 @@
+package fete.be.domain.ticket.application.dto.request;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class CancelTicketsRequest {
+    private List<Long> ticketIds;  // 취소할 participantId 리스트
+    private String cancelReason;  // 토스 결제 취소 사유
+}

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -65,6 +65,7 @@ public enum ResponseMessage {
     TICKET_GET_CUSTOMER_KEY_FAILURE(1206, "고객 키 조회에 실패하였습니다."),
     TICKET_IS_NOT_PAID(1207, "결제되지 않은 티켓입니다."),
     TICKET_INVALID_AMOUNT(1208, "올바르지 않은 금액의 티켓입니다."),
+    TICKET_INVALID_CANCEL_REASON(1209, "올바르지 않은 취소 사유입니다."),
 
     // LIKE
     LIKE_SUCCESS(1300, "관심 등록 API 요청이 성공하였습니다."),


### PR DESCRIPTION
TicketController
- cancelTickets: 티켓 취소 API
  - 무료, 유료 티켓을 구분하여 취소 실행
- InvalidCancelReasonException: cancelReason이 올바르지 않을 경우 Exception
- CancelTicketsRequest: 티켓 취소 API의 요청 DTO
- ResponseMessage: TICKET 관련 코드 추가

TossService
- cancelTicket: 결제 금액에 따라 무료 티켓 취소 또는 유료 티켓 취소 메서드로 매핑시키는 메서드
- cancelFreeTicket: 매개 변수 변경
- cancelPayment: 매개 변수 변경, cancelReason 검사 로직 추가
- TossCancelRequest: @Nullable 삭제