### PR TITLE
feat: 티켓 구매 내역 구조 변경 #6 #10

### DIFF
--- a/src/main/java/fete/be/domain/event/exception/NotFoundEventException.java
+++ b/src/main/java/fete/be/domain/event/exception/NotFoundEventException.java
@@ -1,0 +1,7 @@
+package fete.be.domain.event.exception;
+
+public class NotFoundEventException extends RuntimeException {
+    public NotFoundEventException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fete/be/domain/payment/persistence/Payment.java
+++ b/src/main/java/fete/be/domain/payment/persistence/Payment.java
@@ -4,6 +4,7 @@ import fete.be.domain.event.persistence.Event;
 import fete.be.domain.member.persistence.Member;
 import fete.be.domain.payment.application.dto.response.TossPaymentResponse;
 import fete.be.domain.ticket.persistence.Participant;
+import fete.be.global.util.UUIDGenerator;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -36,6 +37,8 @@ public class Payment {
 
     @Column(name = "is_paid")
     private Boolean isPaid;  // 결제 상태 : 지불 = true, 미지불 = false
+    @Column(name = "payment_code")
+    private String paymentCode;  // 결제 시, 발급 받는 고유의 결제번호
 
     // 토스에서 제공하는 응답 값 (중요)-----------
     private int totalAmount;  // 총 결제 금액
@@ -79,18 +82,20 @@ public class Payment {
     // 결제 완료로 전환
     public static void completePayment(Payment payment) {
         payment.isPaid = true;
-
-        LocalDateTime currentTime = LocalDateTime.now();
-        payment.paymentAt = currentTime;
+        payment.paymentAt = LocalDateTime.now();
     }
 
     // 결제 취소로 전환
     public static void cancelPayment(Payment payment) {
         payment.isPaid = false;
         payment.totalAmount = 0;  // 결제 취소되었기 때문에 결제 금액을 0원으로 변경
+        payment.updatedAt = LocalDateTime.now();
+    }
 
-        LocalDateTime currentTime = LocalDateTime.now();
-        payment.updatedAt = currentTime;
+    // 결제번호 생성
+    public static void generatePaymentCode(Payment payment, String paymentCode) {
+        payment.paymentCode = paymentCode;
+        payment.updatedAt = LocalDateTime.now();
     }
 
     // 토스 응답 값 업데이트 메서드
@@ -100,9 +105,7 @@ public class Payment {
         payment.method = tossPaymentResponse.getMethod();
         payment.paymentKey = tossPaymentResponse.getPaymentKey();
         payment.orderId = tossPaymentResponse.getOrderId();
-
-        LocalDateTime currentTime = LocalDateTime.now();
-        payment.paymentAt = currentTime;
+        payment.paymentAt = LocalDateTime.now();
 
         return payment;
     }
@@ -111,9 +114,7 @@ public class Payment {
     public static Payment updateTossCancelInfo(Payment payment, String lastTransactionKey, String cancelReason) {
         payment.lastTransactionKey = lastTransactionKey;
         payment.cancelReason = cancelReason;
-
-        LocalDateTime currentTime = LocalDateTime.now();
-        payment.updatedAt = currentTime;
+        payment.updatedAt = LocalDateTime.now();
 
         return payment;
     }
@@ -121,9 +122,7 @@ public class Payment {
     // 무료 티켓 취소 시, 필드 업데이트
     public static Payment updateCancelInfo(Payment payment, String cancelReason) {
         payment.cancelReason = cancelReason;
-
-        LocalDateTime currentTime = LocalDateTime.now();
-        payment.updatedAt = currentTime;
+        payment.updatedAt = LocalDateTime.now();
 
         return payment;
     }

--- a/src/main/java/fete/be/domain/payment/persistence/PaymentRepository.java
+++ b/src/main/java/fete/be/domain/payment/persistence/PaymentRepository.java
@@ -2,5 +2,8 @@ package fete.be.domain.payment.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    List<Payment> findByPaymentCode(String paymentCode);
 }

--- a/src/main/java/fete/be/domain/ticket/application/TicketService.java
+++ b/src/main/java/fete/be/domain/ticket/application/TicketService.java
@@ -1,11 +1,13 @@
 package fete.be.domain.ticket.application;
 
 import fete.be.domain.event.application.QRCodeService;
+import fete.be.domain.event.exception.NotFoundEventException;
+import fete.be.domain.event.persistence.Event;
+import fete.be.domain.event.persistence.EventRepository;
 import fete.be.domain.member.application.MemberService;
-import fete.be.domain.payment.exception.InvalidPaymentStatusException;
 import fete.be.domain.payment.persistence.Payment;
-import fete.be.domain.ticket.application.dto.response.GetTicketInfoResponse;
-import fete.be.domain.ticket.application.dto.response.TicketDto;
+import fete.be.domain.payment.persistence.PaymentRepository;
+import fete.be.domain.ticket.application.dto.response.*;
 import fete.be.domain.member.persistence.Member;
 import fete.be.domain.ticket.persistence.Participant;
 import fete.be.domain.ticket.persistence.ParticipantRepository;
@@ -27,16 +29,50 @@ public class TicketService {
 
     private final MemberService memberService;
     private final QRCodeService qrCodeService;
+    private final EventRepository eventRepository;
+    private final PaymentRepository paymentRepository;
     private final ParticipantRepository participantRepository;
 
-    public List<TicketDto> getTickets() {
+    public List<TicketEventDto> getEvents() {
         Member member = memberService.findMemberByEmail();
 
-        return participantRepository.findByMember(member)
+        return participantRepository.findByMember(member).stream()
+                .collect(Collectors.groupingBy(participant -> participant.getPayment().getPaymentCode()))
+                .entrySet()
                 .stream()
-                .map(participant -> new TicketDto(participant))
+                .map(entry -> {
+                    List<Participant> participants = entry.getValue();
+
+                    Event event = participants.get(0).getEvent();
+
+                    return new TicketEventDto(event, entry.getKey());
+                })
                 .collect(Collectors.toList());
     }
+
+    public SimpleEventDto getEventInfo(Long eventId) {
+        // 이벤트 조회
+        Event event = eventRepository.findById(eventId).orElseThrow(
+                () -> new NotFoundEventException(ResponseMessage.EVENT_NO_EXIST.getMessage())
+        );
+
+        return new SimpleEventDto(event);
+    }
+
+    public List<SimpleTicketDto> getTickets(String paymentCode) {
+        return paymentRepository.findByPaymentCode(paymentCode).stream()
+                .map(payment -> new SimpleTicketDto(payment))
+                .collect(Collectors.toList());
+    }
+
+//    public List<TicketDto> getTickets() {
+//        Member member = memberService.findMemberByEmail();
+//
+//        return participantRepository.findByMember(member)
+//                .stream()
+//                .map(participant -> new TicketDto(participant))
+//                .collect(Collectors.toList());
+//    }
 
     public GetTicketInfoResponse getTicketInfo(Long participantId) throws Exception {
         // participantId로 Participant 객체 찾아오기
@@ -44,14 +80,17 @@ public class TicketService {
                 () -> new IllegalArgumentException(ResponseMessage.TICKET_NO_EXIST.getMessage())
         );
 
-        // 결제 상태가 아닌 경우 예외 처리
+        // 결제 상태를 검사하기 위해 Payment 객체 조회
         Payment payment = participant.getPayment();
-        if (!payment.getIsPaid()) {
-            throw new InvalidPaymentStatusException(ResponseMessage.TICKET_IS_NOT_PAID.getMessage());
-        }
+        String qrCode;
 
-        // 찾아온 객체를 QR서비스 단의 generateQRCodeBase64에 넣어서 qrCode 발급해오기
-        String qrCode = qrCodeService.generateQRCodeBase64(participant, 250, 250);
+        // 결제 상태에 따라 QR 코드 발급
+        if (payment.getIsPaid()) {
+            // 찾아온 객체를 QR서비스 단의 generateQRCodeBase64에 넣어서 qrCode 발급해오기
+            qrCode = qrCodeService.generateQRCodeBase64(participant, 250, 250);
+        } else {
+            qrCode = "";
+        }
 
         // 리턴 객체 제작
         TicketDto ticket = new TicketDto(participant);

--- a/src/main/java/fete/be/domain/ticket/application/dto/request/GetEventTicketsRequest.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/request/GetEventTicketsRequest.java
@@ -1,0 +1,9 @@
+package fete.be.domain.ticket.application.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class GetEventTicketsRequest {
+    private Long eventId;
+    private String paymentCode;
+}

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/GetEventTicketsResponse.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/GetEventTicketsResponse.java
@@ -1,0 +1,13 @@
+package fete.be.domain.ticket.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetEventTicketsResponse {
+    private SimpleEventDto eventDto;
+    private List<SimpleTicketDto> ticketDtos;
+}

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/GetMyTicketsEventResponse.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/GetMyTicketsEventResponse.java
@@ -1,0 +1,12 @@
+package fete.be.domain.ticket.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetMyTicketsEventResponse {
+    private List<TicketEventDto> ticketEventInfos;
+}

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleEventDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleEventDto.java
@@ -1,0 +1,28 @@
+package fete.be.domain.ticket.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import fete.be.domain.event.persistence.Event;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class SimpleEventDto {
+    private String eventName;
+    private String posterImage;  // 대표 이미지 1장
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime endDate;
+    private String address;
+
+    public SimpleEventDto(Event event) {
+        this.eventName = event.getEventName();
+        this.posterImage = event.getPoster().getPosterImages().get(0).getImageUrl();
+        this.startDate = event.getStartDate();
+        this.endDate = event.getEndDate();
+        this.address = event.getAddress();
+    }
+}

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleTicketDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleTicketDto.java
@@ -1,0 +1,21 @@
+package fete.be.domain.ticket.application.dto.response;
+
+import fete.be.domain.payment.persistence.Payment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleTicketDto {
+    private Long participantId;
+    private String ticketType;
+    private int ticketPrice;
+    private Boolean isPaid;  // 결제 상태 : 지불 = true, 미지불 = false
+
+    public SimpleTicketDto(Payment payment) {
+        this.participantId = payment.getParticipant().getParticipantId();
+        this.ticketType = payment.getTicketType();
+        this.ticketPrice = payment.getTicketPrice();
+        this.isPaid = payment.getIsPaid();
+    }
+}

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/TicketEventDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/TicketEventDto.java
@@ -1,0 +1,30 @@
+package fete.be.domain.ticket.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import fete.be.domain.event.persistence.Event;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class TicketEventDto {
+    private Long eventId;
+    private String eventName;
+    private String posterImage;  // 대표 이미지 1장
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime endDate;
+    private String paymentCode;  // 결제번호
+
+    public TicketEventDto(Event event, String paymentCode) {
+        this.eventId = event.getEventId();
+        this.eventName = event.getEventName();
+        this.posterImage = event.getPoster().getPosterImages().get(0).getImageUrl();
+        this.startDate = event.getStartDate();
+        this.endDate = event.getEndDate();
+        this.paymentCode = paymentCode;
+    }
+}

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -54,6 +54,7 @@ public enum ResponseMessage {
     EVENT_VALID_QR(1103, "QR 코드가 인증되었습니다."),
     EVENT_INVALID_FILE(1104, "잘못된 파일입니다."),
     EVENT_QR_ALREADY_USED(1105, "이미 사용된 QR 코드입니다."),
+    EVENT_NO_EXIST(1106, "해당 이벤트가 존재하지 않습니다."),
 
     // TICKET
     TICKET_SUCCESS(1200, "티켓 조회에 성공하였습니다."),


### PR DESCRIPTION
TicketController
- getEvents: 기존의 '구매한 티켓 조회 API' -> '구매한 티켓의 이벤트 목록 조회 API'로 변경
  - GetMyTicketsEventResponse: 해당 API의 변경된 응답 DTO, 내가 구매한 티켓에 해당하는 이벤트 목록
  - TicketEventDto: 이벤트 정보 및 paymentCode를 담는 DTO
- getEventTickets: 이벤트에서 구매한 나의 티켓 주문 내역 조회 API
  - GetEventTicketsResponse: 해당 API의 응답 DTO, 이벤트 정보와 해당 이벤트에서 결제한 티켓 내역 정보
  - GetEventTicketsRequest: 해당 API의 요청 DTO
  - SimpleEventDto: 이벤트 정보 DTO
  - SimpleTicketDto: 티켓 정보 DTO
- ResponseMessage: EVENT 관련 코드 추가

TicketService
- getEvents: 구매한 티켓의 이벤트 목록 조회 메서드
- getEventInfo: 이벤트 정보 조회 메서드
- getTickets: paymentCode로 티켓 정보 리스트 조회
- getTicketInfo: 결제 취소된 티켓도 QR 코드를 제외한 정보를 조회할 수 있도록 변경
- NotFoundEventException: 해당 이벤트가 존재하지 않을 경우에 대한 Exception

EventService
- updatePaymentInfo: 결제 정보를 업데이트 하는 메서드
- paymentSystem: 결제 이후, 결제번호를 발급받는 로직 추가

Payment
- paymentCode 필드 추가
- generatePaymentCode: 결제번호 발급 메서드

PaymentRepository
- findByPaymentCode: paymentCode로 결제 정보를 조회