### PR TITLE
feat: API의 응답 필드 변경

### DIFF
--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -178,7 +178,7 @@ public class PosterService {
         Member member = memberService.findMemberByEmail();
 
         // 조건에 맞는 데이터 조회
-        return posterRepository.findByMember(member, pageable)
+        return posterRepository.findByMemberAndStatusNot(member, Status.DELETE, pageable)
                 .map(poster -> {
                     Boolean isLike = posterLikeRepository.findByMemberIdAndPosterId(member.getMemberId(), poster.getPosterId()).isPresent();
                     return new PosterDto(poster, isLike);

--- a/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
+++ b/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface PosterRepository extends JpaRepository<Poster, Long> {
     Page<Poster> findByStatus(Status status, Pageable pageable);
 
-    Page<Poster> findByMember(Member member, Pageable pageable);
+    Page<Poster> findByMemberAndStatusNot(Member member, Status status, Pageable pageable);
 
     Page<Poster> findByPosterIdIn(List<Long> posterIds, Pageable pageable);
 

--- a/src/main/java/fete/be/domain/poster/web/PosterController.java
+++ b/src/main/java/fete/be/domain/poster/web/PosterController.java
@@ -162,7 +162,7 @@ public class PosterController {
 
 
     /**
-     * 자신이 등록한 포스터 조회 API
+     * 내가 등록한 포스터 조회 API
      *
      * @param int page
      * @param int size

--- a/src/main/java/fete/be/domain/ticket/application/TicketService.java
+++ b/src/main/java/fete/be/domain/ticket/application/TicketService.java
@@ -44,8 +44,9 @@ public class TicketService {
                     List<Participant> participants = entry.getValue();
 
                     Event event = participants.get(0).getEvent();
+                    Payment payment = participants.get(0).getPayment();
 
-                    return new TicketEventDto(event, entry.getKey());
+                    return new TicketEventDto(event, payment, entry.getKey());
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleTicketDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleTicketDto.java
@@ -11,11 +11,13 @@ public class SimpleTicketDto {
     private String ticketType;
     private int ticketPrice;
     private Boolean isPaid;  // 결제 상태 : 지불 = true, 미지불 = false
+    private Boolean isParticipated;  // 티켓 사용 여부
 
     public SimpleTicketDto(Payment payment) {
         this.participantId = payment.getParticipant().getParticipantId();
         this.ticketType = payment.getTicketType();
         this.ticketPrice = payment.getTicketPrice();
         this.isPaid = payment.getIsPaid();
+        this.isParticipated = payment.getParticipant().getIsParticipated();
     }
 }

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/TicketDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/TicketDto.java
@@ -22,6 +22,11 @@ public class TicketDto {
     private String ticketType;
     private int ticketPrice;
     private Boolean isPaid;  // 결제 상태 : 지불 = true, 미지불 = false
+    private int totalAmount;  // 총 결제 금액
+    private String method;  // 결제 수단
+    private String cancelReason;  // 취소 사유
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime paymentAt;  // 결제일자
 
     public TicketDto(Participant participant) {
         this.participantId = participant.getParticipantId();
@@ -33,5 +38,9 @@ public class TicketDto {
         this.ticketType = participant.getPayment().getTicketType();
         this.ticketPrice = participant.getPayment().getTicketPrice();
         this.isPaid = participant.getPayment().getIsPaid();
+        this.totalAmount = participant.getPayment().getTotalAmount();
+        this.method = participant.getPayment().getMethod();
+        this.cancelReason = participant.getPayment().getCancelReason();
+        this.paymentAt = participant.getPayment().getPaymentAt();
     }
 }

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/TicketEventDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/TicketEventDto.java
@@ -2,6 +2,7 @@ package fete.be.domain.ticket.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import fete.be.domain.event.persistence.Event;
+import fete.be.domain.payment.persistence.Payment;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,13 +19,18 @@ public class TicketEventDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime endDate;
     private String paymentCode;  // 결제번호
+    private Boolean isPaid;  // 결제 상태 : 지불 = true, 미지불 = false
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime paymentAt;  // 결제일자
 
-    public TicketEventDto(Event event, String paymentCode) {
+    public TicketEventDto(Event event, Payment payment, String paymentCode) {
         this.eventId = event.getEventId();
         this.eventName = event.getEventName();
         this.posterImage = event.getPoster().getPosterImages().get(0).getImageUrl();
         this.startDate = event.getStartDate();
         this.endDate = event.getEndDate();
         this.paymentCode = paymentCode;
+        this.isPaid = payment.getIsPaid();
+        this.paymentAt = payment.getPaymentAt();
     }
 }

--- a/src/main/java/fete/be/domain/ticket/persistence/Participant.java
+++ b/src/main/java/fete/be/domain/ticket/persistence/Participant.java
@@ -29,7 +29,7 @@ public class Participant {
     private Payment payment;  // 결제 상태
 
     @Column(name = "is_participated")
-    private Boolean isParticipated;  // 참여 여부
+    private Boolean isParticipated;  // 티켓 사용 여부
     @Column(name = "created_at")
     private LocalDateTime createdAt;  // 생성일자
     @Column(name = "updated_at")


### PR DESCRIPTION
내가 등록한 포스터 조회 API 
- 삭제된 포스터 안나오게 처리

티켓의 이벤트 목록 조회 API 
- paymentAt, isPaid 필드 추가

티켓 상세 조회 API
- paymentAt, method, totalAmount, cancelReason 필드 추가

이벤트 내 구매내역 조회 API
- isParticipated 필드 추가