### PR TITLE
feat: 카테고리에 나오는 피드에 필드 추가 #5 #14

### DIFF
--- a/src/main/java/fete/be/domain/admin/application/dto/response/SimplePosterDto.java
+++ b/src/main/java/fete/be/domain/admin/application/dto/response/SimplePosterDto.java
@@ -21,8 +21,9 @@ public class SimplePosterDto {
     private LocalDateTime endDate;  // 이벤트 종료일
     private String address;  // 주소
     private Genre genre;  // 장르
+    private Boolean isLike;  // 사용자의 관심 등록 상태
 
-    public SimplePosterDto(Poster poster) {
+    public SimplePosterDto(Poster poster, Boolean isLike) {
         this.posterId = poster.getPosterId();
         this.title = poster.getTitle();
         this.posterImage = poster.getPosterImages().get(0).getImageUrl();
@@ -31,5 +32,6 @@ public class SimplePosterDto {
         this.endDate = poster.getEvent().getEndDate();
         this.address = poster.getEvent().getAddress();
         this.genre = poster.getEvent().getGenre();
+        this.isLike = isLike;
     }
 }

--- a/src/main/java/fete/be/domain/category/web/CategoryController.java
+++ b/src/main/java/fete/be/domain/category/web/CategoryController.java
@@ -3,6 +3,7 @@ package fete.be.domain.category.web;
 import fete.be.domain.category.application.CategoryService;
 import fete.be.domain.category.application.dto.response.CategoryDto;
 import fete.be.domain.category.application.dto.response.GetCategoriesResponse;
+import fete.be.domain.member.exception.GuestUserException;
 import fete.be.global.util.ApiResponse;
 import fete.be.global.util.Logging;
 import fete.be.global.util.ResponseMessage;
@@ -30,17 +31,21 @@ public class CategoryController {
      */
     @GetMapping
     public ApiResponse<GetCategoriesResponse> getCategories() {
-        try {
-            log.info("GetCategories API");
-            Logging.time();
+        log.info("GetCategories API");
+        Logging.time();
 
+        try {
             // 카테고리 전체 조회 (페이징 없이)
             List<CategoryDto> categories = categoryService.getCategories();
             GetCategoriesResponse result = new GetCategoriesResponse(categories);
 
             return new ApiResponse<>(ResponseMessage.CATEGORY_GET_CATEGORIES.getCode(), ResponseMessage.CATEGORY_GET_CATEGORIES.getMessage(), result);
-        } catch (IllegalArgumentException e) {
-            return new ApiResponse<>(ResponseMessage.CATEGORY_GET_CATEGORIES_FAIL.getCode(), e.getMessage());
+        } catch (GuestUserException e) {
+            // 게스트용 카테고리 전체 조회 (페이징 없이)
+            List<CategoryDto> categories = categoryService.getGuestCategories();
+            GetCategoriesResponse result = new GetCategoriesResponse(categories);
+
+            return new ApiResponse<>(ResponseMessage.CATEGORY_GET_CATEGORIES.getCode(), ResponseMessage.CATEGORY_GET_CATEGORIES.getMessage(), result);
         }
     }
 

--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -296,7 +296,10 @@ public class PosterService {
 
         // 조건에 맞는 Poster 가져오기
         return posterRepository.findByStatus(status, pageable)
-                .map(poster -> new SimplePosterDto(poster));
+                .map(poster -> {
+                    Boolean isLike = false;
+                    return new SimplePosterDto(poster, isLike);
+                });
     }
 
     // 관리자용 아티스트 프로필 이미지 등록


### PR DESCRIPTION
CategoryController
- getCategories: 게스트용 조회 분리

CategoryService
- getCategories: 유저의 카테고리 조회
- getGuestCategories: 게스트의 카테고리 조회

PosterService
- getSimplePosters: 관리자용 간편 포스터 조회에 isLike 필드 추가

SimplePosterDto
- isLike 필드 추가
- 커스텀 생성자: 추가된 필드 반영