### PR TITLE
feat: jwt 토큰 만료 시간 재설정 #4

### DIFF
--- a/src/main/java/fete/be/global/jwt/JwtProvider.java
+++ b/src/main/java/fete/be/global/jwt/JwtProvider.java
@@ -40,14 +40,13 @@ public class JwtProvider {
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("auth", authorities)
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 1))  // 30분
-//                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 15))  // 15일
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60))  // 1시간
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
         // Refresh Token 생성
         String refreshToken = Jwts.builder()
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24))  // 1일
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 14))  // 14일
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 


### PR DESCRIPTION
JwtProvider
- accessToken: 1시간으로 변경
- refreshToken: 14일로 변경