### PR TITLE
feat: 배너와 포스터를 1대1 매핑 #12

### DIFF
--- a/src/main/java/fete/be/domain/admin/web/AdminController.java
+++ b/src/main/java/fete/be/domain/admin/web/AdminController.java
@@ -6,6 +6,7 @@ import fete.be.domain.admin.application.dto.request.*;
 import fete.be.domain.admin.application.dto.response.*;
 import fete.be.domain.admin.exception.NotFoundNoticeException;
 import fete.be.domain.banner.application.BannerService;
+import fete.be.domain.banner.exception.AlreadyExistsPosterException;
 import fete.be.domain.category.application.CategoryService;
 import fete.be.domain.member.application.MemberService;
 import fete.be.domain.notice.application.NoticeService;
@@ -217,6 +218,8 @@ public class AdminController {
             Long savedBannerId = bannerService.createBanner(request);
 
             return new ApiResponse<>(ResponseMessage.ADMIN_CREATE_BANNER.getCode(), ResponseMessage.ADMIN_CREATE_BANNER.getMessage());
+        } catch (AlreadyExistsPosterException e) {
+            return new ApiResponse<>(ResponseMessage.ADMIN_CREATE_BANNER_FAIL.getCode(), e.getMessage());
         } catch (IllegalArgumentException e) {
             return new ApiResponse<>(ResponseMessage.ADMIN_CREATE_BANNER_FAIL.getCode(), e.getMessage());
         }

--- a/src/main/java/fete/be/domain/banner/application/BannerService.java
+++ b/src/main/java/fete/be/domain/banner/application/BannerService.java
@@ -3,9 +3,11 @@ package fete.be.domain.banner.application;
 import fete.be.domain.admin.application.dto.request.CreateBannerRequest;
 import fete.be.domain.admin.application.dto.request.ModifyBannerRequest;
 import fete.be.domain.banner.application.dto.response.BannerDto;
+import fete.be.domain.banner.exception.AlreadyExistsPosterException;
 import fete.be.domain.banner.persistence.Banner;
 import fete.be.domain.banner.persistence.BannerRepository;
 import fete.be.domain.poster.application.PosterService;
+import fete.be.domain.poster.persistence.Poster;
 import fete.be.global.util.ResponseMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,6 +30,15 @@ public class BannerService {
 
     @Transactional
     public Long createBanner(CreateBannerRequest request) {
+        // 연결할 posterId
+        Long posterId = request.getPosterId();
+        Poster poster = posterService.findPosterByPosterId(posterId);
+
+        // 해당 포스터로 연결된 배너가 존재하는지 검사
+        if (bannerRepository.existsByPoster(poster)) {
+            throw new AlreadyExistsPosterException(ResponseMessage.POSTER_ALREADY_EXIST.getMessage());
+        }
+
         Banner banner = Banner.createBanner(request, posterService);
         Banner savedBanner = bannerRepository.save(banner);
 

--- a/src/main/java/fete/be/domain/banner/exception/AlreadyExistsPosterException.java
+++ b/src/main/java/fete/be/domain/banner/exception/AlreadyExistsPosterException.java
@@ -1,0 +1,7 @@
+package fete.be.domain.banner.exception;
+
+public class AlreadyExistsPosterException extends RuntimeException {
+    public AlreadyExistsPosterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fete/be/domain/banner/persistence/BannerRepository.java
+++ b/src/main/java/fete/be/domain/banner/persistence/BannerRepository.java
@@ -1,7 +1,8 @@
 package fete.be.domain.banner.persistence;
 
+import fete.be.domain.poster.persistence.Poster;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BannerRepository extends JpaRepository<Banner, Long> {
-
+    boolean existsByPoster(Poster poster);
 }

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -142,6 +142,7 @@ public enum ResponseMessage {
     BANNER_GET_BANNERS(1400, "배너 전체 조회에 성공하였습니다."),
     BANNER_GET_BANNERS_FAIL(1401, "배너 전체 조회에 실패하였습니다."),
     BANNER_NO_EXIST(1402, "해당 배너가 존재하지 않습니다."),
+    POSTER_ALREADY_EXIST(1403, "해당 포스터의 배너가 존재합니다."),
 
     // POPUP
     POPUP_GET_POPUPS(1500, "팝업 전체 조회에 성공하였습니다."),


### PR DESCRIPTION
AdminController
- createBanner: 이미 존재하는 포스터에 대한 배너일 경우에 대한 예외사항 처리
- AlreadyExistsPosterException: 배너에 요청 받은 포스터가 이미 존재하는 경우에 대한 Exception

BannerService
- createBanner: 요청 받은 포스터로 연결된 배너가 존재하는지 검사하는 로직 추가

BannerRepository
- existsByPoster: 해당 포스터와 연결된 배너가 존재하는지 검사