### PR TITLE
fix: 포스터 검색 API 오류 해결 #5

### DIFF
--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -257,7 +257,7 @@ public class PosterService {
         Member member = memberService.findMemberByEmail();
 
         // 포스터의 제목 또는 이벤트 설명에 해당 키워드가 포함되어 있는 포스터들만 조회
-        return posterRepository.findByStatusAndEventEventNameContainingOrEventDescriptionContaining(Status.ACTIVE, keyword, keyword, pageable)
+        return posterRepository.findByKeyword(keyword, pageable)
                 .map(poster -> {
                     Boolean isLike = posterLikeRepository.findByMemberIdAndPosterId(member.getMemberId(), poster.getPosterId()).isPresent();
                     return new PosterDto(poster, isLike);
@@ -269,7 +269,7 @@ public class PosterService {
         Pageable pageable = createPageable(page, size);
 
         // 포스터의 제목 또는 이벤트 설명에 해당 키워드가 포함되어 있는 포스터들만 조회
-        return posterRepository.findByStatusAndEventEventNameContainingOrEventDescriptionContaining(Status.ACTIVE, keyword, keyword, pageable)
+        return posterRepository.findByKeyword(keyword, pageable)
                 .map(poster -> {
                     Boolean isLike = false;
                     return new PosterDto(poster, isLike);

--- a/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
+++ b/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
@@ -19,7 +19,8 @@ public interface PosterRepository extends JpaRepository<Poster, Long> {
 
     Page<Poster> findByPosterIdIn(List<Long> posterIds, Pageable pageable);
 
-    Page<Poster> findByStatusAndEventEventNameContainingOrEventDescriptionContaining(Status status, String keyword1, String keyword2, Pageable pageable);
+    @Query("SELECT p FROM Poster p WHERE (p.event.eventName LIKE %:keyword% OR p.event.description LIKE %:keyword%) AND p.status = 'ACTIVE'")
+    Page<Poster> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     Optional<Poster> findByStatusAndPosterId(Status status, Long posterId);
 


### PR DESCRIPTION
PosterService
- searchPosters, searchGuestPosters: 포스터 검색 로직 변경

PosterRepository
- findByStatusAndEventEventNameContainingOrEventDescriptionContaining -> findByKeyword로 변경