### PR TITLE
feat: 포스터 조회 관련 API 응답 변경

### DIFF
--- a/src/main/java/fete/be/domain/payment/application/TossService.java
+++ b/src/main/java/fete/be/domain/payment/application/TossService.java
@@ -132,8 +132,6 @@ public class TossService {
             log.info(e.getMessage());
             throw new InvalidTossResponseException(ResponseMessage.INVALID_TOSS_PAYMENT_API_RESPONSE.getMessage());
         }
-        log.info("TossPaymentResponse={}", tossPaymentResponse);
-
 
         // Payment 객체에 취소 관련 정보 저장
         Payment canceledPayment = Payment.updateTossCancelInfo(payment, tossPaymentResponse.getLastTransactionKey(), cancelReason);

--- a/src/main/java/fete/be/domain/poster/application/dto/response/GetPostersResponse.java
+++ b/src/main/java/fete/be/domain/poster/application/dto/response/GetPostersResponse.java
@@ -3,6 +3,7 @@ package fete.be.domain.poster.application.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -12,4 +13,11 @@ import java.util.List;
 public class GetPostersResponse {
     private List<PosterDto> posters;
     private int totalPages;
+    private long totalElements;
+
+    public GetPostersResponse(Page<PosterDto> pageInfo) {
+        this.posters = pageInfo.getContent();
+        this.totalElements = pageInfo.getTotalElements();
+        this.totalPages = (int) Math.ceil((double) totalElements / pageInfo.getSize());
+    }
 }

--- a/src/main/java/fete/be/domain/poster/web/PosterController.java
+++ b/src/main/java/fete/be/domain/poster/web/PosterController.java
@@ -133,19 +133,13 @@ public class PosterController {
 
         try {
             Page<PosterDto> pageInfo = posterService.getPosters(findStatus, page, size);
-            List<PosterDto> posters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(posters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.POSTER_SUCCESS.getCode(), ResponseMessage.POSTER_SUCCESS.getMessage(), result);
         } catch (GuestUserException e) {
             // 게스트용 포스터 전체 조회 메서드 실행
             Page<PosterDto> pageInfo = posterService.getGuestPosters(findStatus, page, size);
-            List<PosterDto> posters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(posters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.POSTER_SUCCESS.getCode(), ResponseMessage.POSTER_SUCCESS.getMessage(), result);
         } catch (Exception e) {
@@ -169,19 +163,13 @@ public class PosterController {
         try {
             // 필터링 포스터 조회
             Page<PosterDto> pageInfo = posterService.getPostersWithFilters(page, size, request);
-            List<PosterDto> posters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(posters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.POSTER_SUCCESS.getCode(), ResponseMessage.POSTER_SUCCESS.getMessage(), result);
         } catch (GuestUserException e) {
             // 게스트용 필터링 포스터 조회
             Page<PosterDto> pageInfo = posterService.getGuestPostersWithFilters(page, size, request);
-            List<PosterDto> posters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(posters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.POSTER_SUCCESS.getCode(), ResponseMessage.POSTER_SUCCESS.getMessage(), result);
         } catch (Exception e) {
@@ -237,10 +225,7 @@ public class PosterController {
             Logging.time();
 
             Page<PosterDto> pageInfo = posterService.getMyPosters(page, size);
-            List<PosterDto> myPosters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(myPosters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.POSTER_SUCCESS.getCode(), ResponseMessage.POSTER_SUCCESS.getMessage(), result);
         } catch (IllegalArgumentException e) {
@@ -290,10 +275,7 @@ public class PosterController {
             Logging.time();
 
             Page<PosterDto> pageInfo = posterService.getLikePosters(page, size);
-            List<PosterDto> myLikePosters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(myLikePosters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.LIKE_GET_POSTER_SUCCESS.getCode(), ResponseMessage.LIKE_GET_POSTER_SUCCESS.getMessage(), result);
         } catch (IllegalArgumentException e) {
@@ -326,19 +308,13 @@ public class PosterController {
         try {
             // 제목 또는 설명에 키워드가 포함되어 있는 포스터들 조회
             Page<PosterDto> pageInfo = posterService.searchPosters(keyword, page, size);
-            List<PosterDto> searchedPosters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(searchedPosters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.POSTER_SEARCH_SUCCESS.getCode(), ResponseMessage.POSTER_SEARCH_SUCCESS.getMessage(), result);
         } catch (GuestUserException e) {
             // 게스트용 검색 메서드 실행
             Page<PosterDto> pageInfo = posterService.searchGuestPosters(keyword, page, size);
-            List<PosterDto> searchedPosters = pageInfo.getContent();
-            int totalPages = pageInfo.getTotalPages();
-
-            GetPostersResponse result = new GetPostersResponse(searchedPosters, totalPages);
+            GetPostersResponse result = new GetPostersResponse(pageInfo);
 
             return new ApiResponse<>(ResponseMessage.POSTER_SEARCH_SUCCESS.getCode(), ResponseMessage.POSTER_SEARCH_SUCCESS.getMessage(), result);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
PosterController
- getPosters, getPostersWithFilters, getMyPosters, getLikePosters, searchPosters: 페이징 정보를 생성자 코드에서 처리

GetPostersResponse
- totalElements 필드 추가
- Page 객체를 매개변수로 하는 생성자 추가

PosterService
- createDescPageable: 내림차순 Pageable 객체 생성 메서드
- getOrderSpecifier: Pageable 객체와 QueryDSL 정렬 연동 코드
- getPostersWithFilters, getGuestPostersWithFilters: totalElements 조회 쿼리 추가, 최종 쿼리문에 orderBy 추가