### PR TITLE
feat: 배너 조회 API 로직 추가

### DIFF
--- a/src/main/java/fete/be/domain/banner/application/BannerService.java
+++ b/src/main/java/fete/be/domain/banner/application/BannerService.java
@@ -9,13 +9,13 @@ import fete.be.domain.banner.persistence.BannerRepository;
 import fete.be.domain.poster.application.PosterService;
 import fete.be.domain.poster.persistence.Poster;
 import fete.be.global.util.ResponseMessage;
+import fete.be.global.util.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -74,7 +74,12 @@ public class BannerService {
     }
 
     public List<BannerDto> getBanners() {
+        // 배너에 연결된 포스터의 상태가 ACTIVE, BANNER인 것들만 조회할 것
+        List<Status> wantedStatuses = List.of(Status.ACTIVE, Status.BANNER);
+
+        // 조건에 맞는 배너 전체 조회
         List<BannerDto> banners = bannerRepository.findAll().stream()
+                .filter(banner -> wantedStatuses.contains(banner.getPoster().getStatus()))
                 .map(banner -> new BannerDto(banner))
                 .collect(Collectors.toList());
 

--- a/src/main/java/fete/be/global/util/Status.java
+++ b/src/main/java/fete/be/global/util/Status.java
@@ -5,7 +5,8 @@ public enum Status {
     ACTIVE("ACTIVE"),  // 승인
     DELETE("DELETE"),  // 소프트 삭제
     REPORT("REPORT"),  // 신고
-    END("END")  // 종료
+    END("END"),  // 종료
+    BANNER("BANNER")  // 고정 배너
     ;
 
 

--- a/src/test/java/fete/be/domain/banner/application/BannerServiceTest.java
+++ b/src/test/java/fete/be/domain/banner/application/BannerServiceTest.java
@@ -1,5 +1,6 @@
 package fete.be.domain.banner.application;
 
+import fete.be.domain.admin.application.dto.request.ApprovePostersRequest;
 import fete.be.domain.admin.application.dto.request.CreateBannerRequest;
 import fete.be.domain.admin.application.dto.request.ModifyBannerRequest;
 import fete.be.domain.admin.application.dto.response.AccountDto;
@@ -124,9 +125,12 @@ class BannerServiceTest {
     @DisplayName("배너 전체 조회")
     @Test
     void 성공_배너_전체조회() {
-        // given - 배너 등록
+        // given - 포스터 등록 및 승인 -> 배너 등록
         WritePosterRequest writePosterRequest = generateWriteRequest();
         Long posterId = posterService.writePoster(writePosterRequest);
+        ApprovePostersRequest request = new ApprovePostersRequest(List.of(posterId));
+        posterService.approvePosters(request);
+
         CreateBannerRequest createBannerRequest = new CreateBannerRequest("배너 제목", "배너 내용", "www.image.url", posterId);
         Long bannerId = bannerService.createBanner(createBannerRequest);
 


### PR DESCRIPTION
BannerService
- getBanners: 연결된 포스터의 상태가 ACTIVE, BANNER인 배너들만 조회하도록 변경

Status
- BANNER 추가

BannerServiceTest
- 성공_배너_전체조회: 변경된 메서드 반영