### PR TITLE
feat: Payment에 필드 추가, 이벤트 내 구매내역 조회 API 응답 변경

### DIFF
--- a/src/main/java/fete/be/domain/payment/exception/NotFoundTicketStatusException.java
+++ b/src/main/java/fete/be/domain/payment/exception/NotFoundTicketStatusException.java
@@ -1,0 +1,7 @@
+package fete.be.domain.payment.exception;
+
+public class NotFoundTicketStatusException extends RuntimeException {
+    public NotFoundTicketStatusException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fete/be/domain/payment/persistence/Payment.java
+++ b/src/main/java/fete/be/domain/payment/persistence/Payment.java
@@ -59,6 +59,9 @@ public class Payment {
     private LocalDateTime paymentAt;  // 결제일자
     @Column(name = "canceled_at")
     private LocalDateTime canceledAt;  // 취소일자
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ticket_status")
+    private TicketStatus ticketStatus;  // 티켓 상태 : 예매 완료, 취소
 
 
     // 생성 메서드
@@ -84,6 +87,7 @@ public class Payment {
     // 결제 완료로 전환
     public static void completePayment(Payment payment) {
         payment.isPaid = true;
+        payment.ticketStatus = TicketStatus.COMPLETE;
         payment.paymentAt = LocalDateTime.now();
         payment.updatedAt = LocalDateTime.now();
     }
@@ -91,6 +95,7 @@ public class Payment {
     // 결제 취소로 전환
     public static void cancelPayment(Payment payment) {
         payment.isPaid = false;
+        payment.ticketStatus = TicketStatus.CANCEL;
         payment.totalAmount = 0;  // 결제 취소되었기 때문에 결제 금액을 0원으로 변경
         payment.canceledAt = LocalDateTime.now();
         payment.updatedAt = LocalDateTime.now();

--- a/src/main/java/fete/be/domain/payment/persistence/TicketStatus.java
+++ b/src/main/java/fete/be/domain/payment/persistence/TicketStatus.java
@@ -1,0 +1,30 @@
+package fete.be.domain.payment.persistence;
+
+
+import fete.be.domain.payment.exception.NotFoundTicketStatusException;
+
+public enum TicketStatus {
+    COMPLETE("COMPLETE"),
+    CANCEL("CANCEL"),
+    ;
+
+
+    private String ticketStatus;
+
+    TicketStatus(String ticketStatus) {
+        this.ticketStatus = ticketStatus;
+    }
+
+    public String getTicketStatus() {
+        return this.ticketStatus;
+    }
+
+    public static TicketStatus convertTicketStatus(String ticketStatus) {
+        for (TicketStatus status : TicketStatus.values()) {
+            if (status.getTicketStatus().equals(ticketStatus)) {
+                return status;
+            }
+        }
+        throw new NotFoundTicketStatusException("일치하는 티켓 상태가 없습니다 : " + ticketStatus);
+    }
+}

--- a/src/main/java/fete/be/domain/ticket/application/dto/request/GetEventTicketsRequest.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/request/GetEventTicketsRequest.java
@@ -8,4 +8,5 @@ import lombok.NoArgsConstructor;
 public class GetEventTicketsRequest {
     private Long eventId;
     private String paymentCode;
+    private String ticketStatus;
 }

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleTicketDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/SimpleTicketDto.java
@@ -1,6 +1,7 @@
 package fete.be.domain.ticket.application.dto.response;
 
 import fete.be.domain.payment.persistence.Payment;
+import fete.be.domain.payment.persistence.TicketStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ public class SimpleTicketDto {
     private Boolean isPaid;  // 결제 상태 : 지불 = true, 미지불 = false
     private String qrCode;  // QR 코드
     private Boolean isParticipated;  // 티켓 사용 여부
+    private TicketStatus ticketStatus;  // 티켓 상태
 
     public SimpleTicketDto(Payment payment, String qrCode) {
         this.participantId = payment.getParticipant().getParticipantId();
@@ -23,5 +25,6 @@ public class SimpleTicketDto {
         this.isPaid = payment.getIsPaid();
         this.qrCode = qrCode;
         this.isParticipated = payment.getParticipant().getIsParticipated();
+        this.ticketStatus = payment.getTicketStatus();
     }
 }

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/TicketDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/TicketDto.java
@@ -2,6 +2,7 @@ package fete.be.domain.ticket.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import fete.be.domain.event.persistence.EventType;
+import fete.be.domain.payment.persistence.TicketStatus;
 import fete.be.domain.ticket.persistence.Participant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,6 +30,7 @@ public class TicketDto {
     private String cancelReason;  // 취소 사유
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime paymentAt;  // 결제일자
+    private TicketStatus ticketStatus;  // 티켓 상태
 
     public TicketDto(Participant participant) {
         this.participantId = participant.getParticipantId();
@@ -51,5 +53,6 @@ public class TicketDto {
         this.method = participant.getPayment().getMethod();
         this.cancelReason = participant.getPayment().getCancelReason();
         this.paymentAt = participant.getPayment().getPaymentAt();
+        this.ticketStatus = participant.getPayment().getTicketStatus();
     }
 }

--- a/src/main/java/fete/be/domain/ticket/application/dto/response/TicketEventDto.java
+++ b/src/main/java/fete/be/domain/ticket/application/dto/response/TicketEventDto.java
@@ -3,6 +3,7 @@ package fete.be.domain.ticket.application.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import fete.be.domain.event.persistence.Event;
 import fete.be.domain.payment.persistence.Payment;
+import fete.be.domain.payment.persistence.TicketStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,7 +27,7 @@ public class TicketEventDto {
     private LocalDateTime paymentAt;  // 결제일자
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime canceledAt;  // 취소일자
-
+    private TicketStatus ticketStatus;  // 티켓 상태
 
     public TicketEventDto(Event event, Payment payment, String paymentCode) {
         this.eventId = event.getEventId();
@@ -45,5 +46,6 @@ public class TicketEventDto {
         this.isPaid = payment.getIsPaid();
         this.paymentAt = payment.getPaymentAt();
         this.canceledAt = payment.getCanceledAt();
+        this.ticketStatus = payment.getTicketStatus();
     }
 }

--- a/src/main/java/fete/be/domain/ticket/web/TicketController.java
+++ b/src/main/java/fete/be/domain/ticket/web/TicketController.java
@@ -72,7 +72,7 @@ public class TicketController {
             SimpleEventDto eventDto = ticketService.getEventInfo(eventId);
 
             // 해당 이벤트에서 주문한 티켓 정보들
-            List<SimpleTicketDto> ticketDtos = ticketService.getTickets(paymentCode);
+            List<SimpleTicketDto> ticketDtos = ticketService.getTickets(paymentCode, request.getTicketStatus());
 
             GetEventTicketsResponse result = new GetEventTicketsResponse(eventDto, ticketDtos);
             return new ApiResponse<>(ResponseMessage.TICKET_SUCCESS.getCode(), ResponseMessage.TICKET_SUCCESS.getMessage(), result);


### PR DESCRIPTION
Payment
- ticketStatus: 티켓 상태를 나타내는 필드 추가

TicketStatus
- 티켓 상태를 관리하는 Enum
- NotFoundTicketStatusException: 해당하는 티켓 상태가 없을 경우에 대한 예외 처리

TicketController
- getEventTickets: 구매한 티켓의 상태에 따라 필터링 할 수 있도록 변경

TicketService
- getTickets: 이전 버전 메서드를 QueryDSL을 사용하여 리팩토링, 필터링 기능 추가