### PR TITLE
feat: 포스터 반려 기능 추가 #7

### DIFF
--- a/src/main/java/fete/be/domain/admin/application/dto/request/RejectPosterRequest.java
+++ b/src/main/java/fete/be/domain/admin/application/dto/request/RejectPosterRequest.java
@@ -1,0 +1,15 @@
+package fete.be.domain.admin.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class RejectPosterRequest {
+    private Long posterId;
+    private String reason;
+}

--- a/src/main/java/fete/be/domain/admin/web/AdminController.java
+++ b/src/main/java/fete/be/domain/admin/web/AdminController.java
@@ -64,8 +64,28 @@ public class AdminController {
 
             posterService.approvePosters(request);
             return new ApiResponse<>(ResponseMessage.ADMIN_APPROVE_POSTERS.getCode(), ResponseMessage.ADMIN_APPROVE_POSTERS.getMessage());
-        } catch (IllegalArgumentException e) {
+        } catch (NotFoundPosterException e) {
             return new ApiResponse<>(ResponseMessage.ADMIN_APPROVE_POSTERS_FAIL.getCode(), e.getMessage());
+        }
+    }
+
+
+    /**
+     * 관리자의 포스터 반려 API
+     *
+     * @param RejectPosterRequest request
+     * @return ApiResponse
+     */
+    @PostMapping("/posters/reject")
+    public ApiResponse rejectPoster(@RequestBody RejectPosterRequest request) {
+        try {
+            log.info("RejectPoster request={}", request);
+            Logging.time();
+
+            posterService.rejectPoster(request);
+            return new ApiResponse<>(ResponseMessage.ADMIN_REJECT_POSTER.getCode(), ResponseMessage.ADMIN_REJECT_POSTER.getMessage());
+        } catch (NotFoundPosterException e) {
+            return new ApiResponse<>(ResponseMessage.ADMIN_REJECT_POSTER_FAIL.getCode(), e.getMessage());
         }
     }
 

--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import fete.be.domain.admin.application.dto.request.RejectPosterRequest;
 import fete.be.domain.admin.application.dto.request.SetArtistImageUrlsRequest;
 import fete.be.domain.admin.application.dto.response.AccountDto;
 import fete.be.domain.admin.application.dto.response.SimplePosterDto;
@@ -349,6 +350,15 @@ public class PosterService {
         for (Poster poster : posters) {
             Poster.approvePoster(poster);  // 관리자 승인 메서드 실행
         }
+    }
+
+    @Transactional
+    public void rejectPoster(RejectPosterRequest request) {
+        Long posterId = request.getPosterId();
+        String reason = request.getReason();
+        Poster poster = findPosterByPosterId(posterId);
+
+        Poster.rejectPoster(poster, reason);  // 관리자 포스터 반려 메서드 실행
     }
 
     public Page<PosterDto> getMyPosters(int page, int size) {

--- a/src/main/java/fete/be/domain/poster/persistence/Poster.java
+++ b/src/main/java/fete/be/domain/poster/persistence/Poster.java
@@ -61,6 +61,9 @@ public class Poster {
     @Column(name = "status")
     private Status status;  // 포스터 상태
 
+    @Column(name = "reason")
+    private String reason;  // 포스터 반려 이유
+    @Column(name = "like_count")
     private int likeCount;  // 관심 등록 수
 
 
@@ -157,9 +160,18 @@ public class Poster {
         return poster;
     }
 
-    // 관리자 승인 메서드
+    // 관리자 포스터 승인 메서드
     public static void approvePoster(Poster poster) {
         poster.status = Status.ACTIVE;  // WAIT -> ACTIVE로 전환
+
+        LocalDateTime currentTime = LocalDateTime.now();
+        poster.updatedAt = currentTime;
+    }
+
+    // 관리자 포스터 반려 메서드
+    public static void rejectPoster(Poster poster, String reason) {
+        poster.status = Status.REJECT;  // REJECT로 전환
+        poster.reason = reason;
 
         LocalDateTime currentTime = LocalDateTime.now();
         poster.updatedAt = currentTime;

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -145,6 +145,8 @@ public enum ResponseMessage {
     IS_NOT_ADMIN(7039, "관리자 권한이 없습니다."),
     ADMIN_MODIFY_SIMPLE_ADDRESS_SUCCESS(7040, "간단 주소 수정이 성공하였습니다."),
     ADMIN_MODIFY_SIMPLE_ADDRESS_FAIL(7041, "간단 주소 수정이 실패하였습니다."),
+    ADMIN_REJECT_POSTER(7042, "관리자의 포스터 반려가 성공하였습니다."),
+    ADMIN_REJECT_POSTER_FAIL(7043, "관리자의 포스터 반려가 실패하였습니다."),
 
     // BANNER
     BANNER_GET_BANNERS(1400, "배너 전체 조회에 성공하였습니다."),

--- a/src/main/java/fete/be/global/util/Status.java
+++ b/src/main/java/fete/be/global/util/Status.java
@@ -3,6 +3,7 @@ package fete.be.global.util;
 public enum Status {
     WAIT("WAIT"),  // 승인 전
     ACTIVE("ACTIVE"),  // 승인
+    REJECT("REJECT"),  // 반려
     DELETE("DELETE"),  // 소프트 삭제
     REPORT("REPORT"),  // 신고
     END("END"),  // 종료


### PR DESCRIPTION
AdminController
- rejectPoster: 관리자의 포스터 반려 API 추가
- RejectPosterRequest: 해당 API의 요청 DTO
- ResponseMessage: ADMIN 관련 코드 추가

PosterService
- rejectPoster: 포스터 반려 및 이유를 등록하는 메서드

Poster
- reason 필드 추가
- rejectPoster: 관리자의 포스터 반려 메서드

Status
- REJECT 상태 추가