### PR TITLE
feat: 임시 담당자 권한 부여 기능 추가 #6

### DIFF
--- a/src/main/java/fete/be/domain/event/application/EventService.java
+++ b/src/main/java/fete/be/domain/event/application/EventService.java
@@ -39,6 +39,7 @@ public class EventService {
     private final PosterService posterService;
     private final QRCodeService qrCodeService;
     private final TossService tossService;
+
     private final ParticipantRepository participantRepository;
     private final PaymentRepository paymentRepository;
 
@@ -238,6 +239,22 @@ public class EventService {
         for (BuyTicketDto requestTicket : requestTickets) {
             canBuy(requestTicket, tickets);
         }
+    }
+
+    /**
+     * 임시 담당자 권한 부여하는 메서드
+     */
+    @Transactional
+    public void grantTempManager(String managerCode) {
+        // 포스터에서 managerCode로 포스터 조회
+        Poster poster = posterService.findPosterByManagerCode(managerCode);
+
+        // 현재 유저 조회
+        Member member = memberService.findMemberByEmail();
+
+        // 조회한 포스터 담당자에 현재 유저 추가 & 멤버와 해당 포스터 연결
+        poster.addManager(member);
+        member.setManagedPoster(poster);
     }
 
     private void canBuy(BuyTicketDto requestTicket, List<Ticket> tickets) {

--- a/src/main/java/fete/be/domain/event/application/QRCodeService.java
+++ b/src/main/java/fete/be/domain/event/application/QRCodeService.java
@@ -27,6 +27,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.Base64;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -126,15 +127,13 @@ public class QRCodeService {
         // posterId로 포스터 찾기
         Poster poster = posterService.findPosterByPosterId(posterId);
 
-//        // 담당자 검사 - 메인 담당자가 아니라면, 포스터의 고유 식별코드를 확인해서 임시 담당자인지 검사
-//        Member manager = poster.getMember();
-//        Member currentMember = memberService.findMemberByEmail();
-//        String managerCode = poster.getManagerCode();
-//        if (!manager.equals(currentMember)) {  // 메인 담당자가 아니라면
-//            if (!managerCode.equals(request.getManagerCode())) {  // 임시 담당자도 아니라면
-//                throw new AccessDeniedException(ResponseMessage.EVENT_INCORRECT_MANAGER.getMessage());
-//            }
-//        }
+        // 담당자 검사 - 메인 담당자, 임시 담당자 포함되는지 검사
+        Member mainManager = poster.getMember();
+        List<Member> managers = poster.getManagers();
+        Member member = memberService.findMemberByEmail();
+        if (!managers.contains(member) && !mainManager.equals(member)) {  // 임시 담당자 목록 또는 등록 담당자가 아닐 경우
+            throw new AccessDeniedException(ResponseMessage.EVENT_INCORRECT_MANAGER.getMessage());
+        }
 
         // 검증 로직
         // 해당 QR 코드가 사용된 적 있는지 확인
@@ -263,29 +262,4 @@ public class QRCodeService {
 
         return bufferedImage;
     }
-//
-//    public static void main(String[] args) throws IOException, NotFoundException {
-//
-//        ObjectMapper objectMapper = new ObjectMapper();
-//
-//        String base64Image = "iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6AQAAAACgl2eQAAABv0lEQVR4Xu2Y0W3DMAxECXgAj+TVNZIHEKDeOyapExTtbw8wkRiW9PxxII90Uuv3GPW58xE30HEDHTfQYWCUYh+bbk/dHdt5TLb6LAbQd+6Lax2161pesh8EeGe0xiWNYvYh4YmAcqQF+yfLUIBiW2s7KxRYLrlNpK6nq+6nmvznAFbfdXr5sNVnKcAjLHCQrEvkAJIpyw/dFU2MYlPiriWXAFBsMgsDhRtNk/70wykAJWenyC8I3LD/+qjJfw+QI/owA4X1pKG16iAAXS/mmbI4wPFknKkBnAYg8zFQbJxnvUUBGh8HCVLWek8+Kh6JAiQQsyyXXGcKpW+tOACQJjvFDrL3p1+9ooCBa7zvehukSYOeDCYBThAy2Sdr9W7/DEACy6+IYgrv083spiRgkiZqjNOnca4llwB0gWEW9QED6I0Dutjch9e08TeWWQCKKDOy5mu3gjCggxyRL48VTr6NEwEgqtsv87EAyFc/lgMshju9q0/LmapLf4gAbBa61vRvwI759iaWAjzEXlrBh8wMYPZAdBOwakM5wELgKP9DgkD6wHGVGQFQYU7W6/2krDoK+C1uoOMGOm6g42/gC2ncmRbHXBdsAAAAAElFTkSuQmCC";
-//
-//        log.info("base64Image={}", base64Image);
-//
-//        // Base64 디코딩하여 BufferedImage로 변환
-//        BufferedImage bufferedImage = decodeQRCodeImage(base64Image);
-//
-//        // QR 코드 이미지에서 QR 코드 텍스트 추출
-//        LuminanceSource source = new BufferedImageLuminanceSource(bufferedImage);
-//        BinaryBitmap bitmap = new BinaryBitmap(new HybridBinarizer(source));
-//
-//        Result result = new MultiFormatReader().decode(bitmap);
-//        String qrCodeText = result.getText();
-//
-//        log.info("qrCodeText={}", qrCodeText);
-//
-//        // 역직렬화
-//        ParticipantDto participantDto = objectMapper.readValue(qrCodeText, ParticipantDto.class);
-//        System.out.println("participantDto = " + participantDto);
-//    }
 }

--- a/src/main/java/fete/be/domain/event/application/dto/request/GrantTempManagerRequest.java
+++ b/src/main/java/fete/be/domain/event/application/dto/request/GrantTempManagerRequest.java
@@ -1,0 +1,15 @@
+package fete.be.domain.event.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class GrantTempManagerRequest {
+    private String managerCode;  // 고유 식별 코드
+}

--- a/src/main/java/fete/be/domain/event/application/dto/response/GetManagerCodeResponse.java
+++ b/src/main/java/fete/be/domain/event/application/dto/response/GetManagerCodeResponse.java
@@ -1,0 +1,12 @@
+package fete.be.domain.event.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetManagerCodeResponse {
+    private String managerCode;  // 고유 식별 코드
+}

--- a/src/main/java/fete/be/domain/event/web/EventController.java
+++ b/src/main/java/fete/be/domain/event/web/EventController.java
@@ -198,9 +198,11 @@ public class EventController {
             String managerCode = posterService.getManagerCode(posterId);
 
             GetManagerCodeResponse result = new GetManagerCodeResponse(managerCode);
-            return new ApiResponse<>(ResponseMessage.TEMP_MANAGER_SUCCESS.getCode(), ResponseMessage.TEMP_MANAGER_SUCCESS.getMessage(), result);
+            return new ApiResponse<>(ResponseMessage.POSTER_CODE_SUCCESS.getCode(), ResponseMessage.POSTER_CODE_SUCCESS.getMessage(), result);
         } catch (NotFoundPosterException e) {
-            return new ApiResponse<>(ResponseMessage.TEMP_MANAGER_FAILURE.getCode(), e.getMessage());
+            return new ApiResponse<>(ResponseMessage.POSTER_CODE_FAILURE.getCode(), e.getMessage());
+        } catch (AccessDeniedException e) {
+            return new ApiResponse<>(ResponseMessage.POSTER_CODE_FAILURE.getCode(), e.getMessage());
         }
     }
 }

--- a/src/main/java/fete/be/domain/event/web/EventController.java
+++ b/src/main/java/fete/be/domain/event/web/EventController.java
@@ -7,6 +7,7 @@ import fete.be.domain.event.application.EventService;
 import fete.be.domain.event.application.QRCodeService;
 import fete.be.domain.event.application.dto.request.BuyTicketRequest;
 import fete.be.domain.event.application.dto.request.CheckTicketsQuantityRequest;
+import fete.be.domain.event.application.dto.request.GrantTempManagerRequest;
 import fete.be.domain.event.application.dto.request.ParticipantDto;
 import fete.be.domain.event.application.dto.response.BuyTicketResponse;
 import fete.be.domain.event.application.dto.response.GetManagerCodeResponse;
@@ -203,6 +204,30 @@ public class EventController {
             return new ApiResponse<>(ResponseMessage.POSTER_CODE_FAILURE.getCode(), e.getMessage());
         } catch (AccessDeniedException e) {
             return new ApiResponse<>(ResponseMessage.POSTER_CODE_FAILURE.getCode(), e.getMessage());
+        }
+    }
+
+
+    /**
+     * 임시 담당자 권한 부여 API
+     * - 포스터 고유식별코드를 입력하여 해당 유저에게 임시 담당자 권한 부여
+     *
+     * @param GrantTempManagerRequest grantTempManagerRequest
+     * @return
+     */
+    @PostMapping("/{posterId}/temp-manager")
+    public ApiResponse grantTempManager(@RequestBody GrantTempManagerRequest grantTempManagerRequest) {
+        log.info("GrantTempManager API");
+        Logging.time();
+
+        try {
+            // 코드를 입력하여 임시 담당자 권한 부여
+            String managerCode = grantTempManagerRequest.getManagerCode();
+            eventService.grantTempManager(managerCode);
+
+            return new ApiResponse<>(ResponseMessage.TEMP_MANAGER_SUCCESS.getCode(), ResponseMessage.TEMP_MANAGER_SUCCESS.getMessage());
+        } catch (NotFoundPosterException e) {
+            return new ApiResponse<>(ResponseMessage.TEMP_MANAGER_FAILURE.getCode(), e.getMessage());
         }
     }
 }

--- a/src/main/java/fete/be/domain/member/persistence/Member.java
+++ b/src/main/java/fete/be/domain/member/persistence/Member.java
@@ -79,6 +79,10 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Poster> posters = new ArrayList<>();  // 유저가 등록한 프스터 리스트
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poster_id")
+    private Poster managedPoster;  // 관리하고 있는 포스터 (현재는 1개만 가능)
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
     @Column(name = "updated_at")
@@ -184,6 +188,17 @@ public class Member {
     // 비밀번호 설정
     public static void setPassword(Member member, String newPassword) {
         member.password = newPassword;
+        member.updatedAt = LocalDateTime.now();
+    }
+
+    // 임시로 관리하고 있는 포스터 지정 메서드
+    public void setManagedPoster(Poster poster) {
+        this.managedPoster = poster;
+    }
+
+    // 관리하고 있는 포스터 초기화 메서드
+    public static void initManagedPoster(Member member) {
+        member.managedPoster = null;
         member.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -86,6 +86,11 @@ public class PosterService {
                 () -> new NotFoundPosterException(ResponseMessage.POSTER_NO_EXIST.getMessage()));
     }
 
+    public Poster findPosterByManagerCode(String managerCode) {
+        return posterRepository.findByManagerCode(managerCode).orElseThrow(
+                () -> new NotFoundPosterException(ResponseMessage.POSTER_NO_EXIST.getMessage()));
+    }
+
     @Transactional
     public Long updatePoster(Long posterId, ModifyPosterRequest request) throws URISyntaxException {
         // 현재 API 요청을 보낸 Member 찾기

--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -4,16 +4,19 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import fete.be.domain.admin.application.dto.request.RejectPosterRequest;
 import fete.be.domain.admin.application.dto.request.SetArtistImageUrlsRequest;
 import fete.be.domain.admin.application.dto.response.AccountDto;
 import fete.be.domain.admin.application.dto.response.SimplePosterDto;
+import fete.be.domain.event.exception.AccessDeniedException;
 import fete.be.domain.event.persistence.*;
 import fete.be.domain.image.application.ImageUploadService;
 import fete.be.domain.member.application.MemberService;
 import fete.be.domain.member.persistence.Member;
 import fete.be.domain.admin.application.dto.request.ApprovePostersRequest;
+import fete.be.domain.member.persistence.QMember;
 import fete.be.domain.member.persistence.Role;
 import fete.be.domain.poster.application.dto.request.Filter;
 import fete.be.domain.poster.application.dto.request.ModifyPosterRequest;
@@ -378,10 +381,12 @@ public class PosterService {
         // 사용할 QClass
         QPoster poster = QPoster.poster;
         QEvent event = QEvent.event;
+        QMember managerMember = QMember.member;
 
         // 동적 쿼리
         BooleanBuilder builder = new BooleanBuilder();
         BooleanBuilder statusBuilder = new BooleanBuilder();
+        BooleanBuilder managerBuilder = new BooleanBuilder();
 
         // 포스터 상태 필터
         statusBuilder.and(poster.status.ne(Status.DELETE));
@@ -390,8 +395,15 @@ public class PosterService {
         }
         builder.and(statusBuilder);
 
-        // 작성자의 글만 조회
-        builder.and(poster.member.eq(member));
+        // 등록자 또는 임시 담당자 필터
+        managerBuilder.or(poster.member.eq(member));
+        managerBuilder.or(JPAExpressions
+                .selectOne()
+                .from(managerMember)
+                .where(managerMember.eq(member)
+                        .and(managerMember.managedPoster.eq(poster)))
+                .exists());
+        builder.and(managerBuilder);
 
         // 전체 데이터 개수 조회 쿼리 실행
         long totalElements = queryFactory.select(poster.count())

--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -412,6 +412,55 @@ public class PosterService {
                 .collect(Collectors.toList()), pageable, totalElements);
     }
 
+//    public Page<PosterDto> getMyPosters(int page, int size, MyPosterFilter filter) {
+//        // 페이징 조건 추가
+//        Pageable pageable = createAscPageable(page, size);
+//
+//        // Member 찾기
+//        Member member = memberService.findMemberByEmail();
+//
+//        // 사용할 QClass
+//        QPoster poster = QPoster.poster;
+//        QEvent event = QEvent.event;
+//
+//        // 동적 쿼리
+//        BooleanBuilder builder = new BooleanBuilder();
+//        BooleanBuilder statusBuilder = new BooleanBuilder();
+//
+//        // 포스터 상태 필터
+//        statusBuilder.and(poster.status.ne(Status.DELETE));
+//        if (filter.getStatus() != null && !filter.getStatus().isBlank()) {
+//            statusBuilder.and(poster.status.eq(Status.valueOf(filter.getStatus())));
+//        }
+//        builder.and(statusBuilder);
+//
+//        // 작성자의 글만 조회
+//        builder.and(poster.member.eq(member));
+//
+//        // 전체 데이터 개수 조회 쿼리 실행
+//        long totalElements = queryFactory.select(poster.count())
+//                .from(poster)
+//                .join(poster.event, event)
+//                .where(builder)
+//                .fetchOne();
+//
+//        // 최종 쿼리 실행
+//        List<Poster> result = queryFactory.selectFrom(poster)
+//                .join(poster.event, event)
+//                .where(builder)
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .orderBy(getOrderSpecifier(pageable.getSort()).stream().toArray(OrderSpecifier[]::new))
+//                .fetch();
+//
+//        return new PageImpl<>(result.stream()
+//                .map(posterItem -> {
+//                    Boolean isLike = posterLikeRepository.findByMemberIdAndPosterId(member.getMemberId(), posterItem.getPosterId()).isPresent();
+//                    return new PosterDto(posterItem, isLike);
+//                })
+//                .collect(Collectors.toList()), pageable, totalElements);
+//    }
+
 
     @Transactional
     public void likePoster(Long posterId, Boolean isLike) {
@@ -546,7 +595,12 @@ public class PosterService {
 
     // 포스터 고유 식별 코드 조회하는 메서드
     public String getManagerCode(Long posterId) {
+        Member member = memberService.findMemberByEmail();
         Poster poster = findPosterByPosterId(posterId);
+        if (!poster.getMember().equals(member)) {
+            throw new AccessDeniedException(ResponseMessage.EVENT_INCORRECT_MANAGER.getMessage());
+        }
+
         return poster.getManagerCode();
     }
 

--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -544,6 +544,12 @@ public class PosterService {
         event.updateSimpleAddress(simpleAddress);
     }
 
+    // 포스터 고유 식별 코드 조회하는 메서드
+    public String getManagerCode(Long posterId) {
+        Poster poster = findPosterByPosterId(posterId);
+        return poster.getManagerCode();
+    }
+
     /**
      * Pageable 객체 생성 (오름차순)
      * - 첫 번째 정렬 기준 : 이벤트의 시작 날짜

--- a/src/main/java/fete/be/domain/poster/persistence/Poster.java
+++ b/src/main/java/fete/be/domain/poster/persistence/Poster.java
@@ -39,6 +39,8 @@ public class Poster {
     private String institution;  // 주최 팀 or 주최자 명
     @Column(name = "manager", nullable = false, length = 20)
     private String manager;  // 담당자 이름
+    @OneToMany(mappedBy = "managedPoster", cascade = CascadeType.PERSIST)
+    private List<Member> managers = new ArrayList<>();  // 임시 담당자 리스트
     @Column(name = "manager_contact", nullable = false, length = 20)
     private String managerContact;  // 담당자 연락처
     @Column(name = "manager_code")
@@ -150,6 +152,11 @@ public class Poster {
         // DB에서 이미지 삭제
         poster.posterImages.clear();
 
+        // 연관된 담당자들의 managedPoster 연결 해제
+        for (Member manager : poster.getManagers()) {
+            Member.initManagedPoster(manager);
+        }
+
         LocalDateTime currentTime = LocalDateTime.now();
         poster.updatedAt = currentTime;
 
@@ -203,5 +210,10 @@ public class Poster {
     // 배너 설정 메서드
     public void setBanner(Banner banner) {
         this.banner = banner;
+    }
+
+    // 임시 담당자 추가
+    public void addManager(Member manager) {
+        this.getManagers().add(manager);
     }
 }

--- a/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
+++ b/src/main/java/fete/be/domain/poster/persistence/PosterRepository.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 public interface PosterRepository extends JpaRepository<Poster, Long> {
     Page<Poster> findByStatus(Status status, Pageable pageable);
 
+    Optional<Poster> findByManagerCode(String managerCode);
+
     Page<Poster> findByMemberAndStatusNot(Member member, Status status, Pageable pageable);
 
     Page<Poster> findByPosterIdIn(List<Long> posterIds, Pageable pageable);

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -80,8 +80,10 @@ public enum ResponseMessage {
     EVENT_INVALID_GENRE_LENGTH(1110, "장르 선택은 최대 3개까지 가능합니다."),
     EVENT_ALREADY_PAYMENT_STATE(1111, "이미 결제된 상태입니다."),
     INVALID_TOSS_PAYMENT_API_RESPONSE(1112, "토스페이먼츠 API에 장애가 발생하였습니다."),
-    TEMP_MANAGER_SUCCESS(1113, "임시 자격 발급에 성공하였습니다."),
-    TEMP_MANAGER_FAILURE(1114, "임시 자격 발급에 실패하였습니다."),
+    POSTER_CODE_SUCCESS(1113, "고유식별코드 전송에 성공하였습니다."),
+    POSTER_CODE_FAILURE(1114, "고유식별코드 전송에 실패하였습니다."),
+    TEMP_MANAGER_SUCCESS(1115, "임시 자격 발급에 성공하였습니다."),
+    TEMP_MANAGER_FAILURE(1116, "임시 자격 발급에 실패하였습니다."),
 
     // TICKET
     TICKET_SUCCESS(1200, "티켓 조회에 성공하였습니다."),

--- a/src/main/java/fete/be/global/util/ResponseMessage.java
+++ b/src/main/java/fete/be/global/util/ResponseMessage.java
@@ -80,6 +80,8 @@ public enum ResponseMessage {
     EVENT_INVALID_GENRE_LENGTH(1110, "장르 선택은 최대 3개까지 가능합니다."),
     EVENT_ALREADY_PAYMENT_STATE(1111, "이미 결제된 상태입니다."),
     INVALID_TOSS_PAYMENT_API_RESPONSE(1112, "토스페이먼츠 API에 장애가 발생하였습니다."),
+    TEMP_MANAGER_SUCCESS(1113, "임시 자격 발급에 성공하였습니다."),
+    TEMP_MANAGER_FAILURE(1114, "임시 자격 발급에 실패하였습니다."),
 
     // TICKET
     TICKET_SUCCESS(1200, "티켓 조회에 성공하였습니다."),


### PR DESCRIPTION
Member
- managedPoster 필드 추가
- setManagedPoster: 임시로 관리하고 있는 포스터 지정 메서드
- initManagedPoster: 관리하고 있는 포스터 초기화 메서드

Poster
- managers 필드 추가
- deletePoster: 연관된 담당자들의 managedPoster 연결 해제 코드 추가
- addManager: 임시 담당자 추가 메서드

PosterService
- getMyPosters: 임시 담당자에게도 '내가 등록한 이벤트'에 관련된 이벤트가 뜨도록 변경

EventService
- grantTempManager: 요청 유저에게 임시 담당자 권한을 부여하는 메서드

QRCodeService
- verifyQRCode: 임시 담당자도 QR 코드를 인증할 수 있도록 변경
