### PR TITLE
feat: 임시 담당자의 포스터 담당 개수 확장 #1 #6

### DIFF
--- a/src/main/java/fete/be/domain/event/application/EventService.java
+++ b/src/main/java/fete/be/domain/event/application/EventService.java
@@ -9,6 +9,7 @@ import fete.be.domain.event.persistence.Ticket;
 import fete.be.domain.payment.application.TossService;
 import fete.be.domain.payment.application.dto.request.TossPaymentRequest;
 import fete.be.domain.payment.persistence.PaymentRepository;
+import fete.be.domain.poster.persistence.PosterManager;
 import fete.be.domain.ticket.persistence.Participant;
 import fete.be.domain.ticket.persistence.ParticipantRepository;
 import fete.be.domain.member.application.MemberService;
@@ -253,8 +254,9 @@ public class EventService {
         Member member = memberService.findMemberByEmail();
 
         // 조회한 포스터 담당자에 현재 유저 추가 & 멤버와 해당 포스터 연결
-        poster.addManager(member);
-        member.setManagedPoster(poster);
+        PosterManager posterManager = PosterManager.createPosterManager(member, poster);
+        poster.addPosterManager(posterManager);
+        member.addPosterManager(posterManager);
     }
 
     private void canBuy(BuyTicketDto requestTicket, List<Ticket> tickets) {

--- a/src/main/java/fete/be/domain/member/persistence/Member.java
+++ b/src/main/java/fete/be/domain/member/persistence/Member.java
@@ -3,6 +3,7 @@ package fete.be.domain.member.persistence;
 import fete.be.domain.member.application.dto.request.ModifyRequestDto;
 import fete.be.domain.member.application.dto.request.OAuthSignupRequest;
 import fete.be.domain.member.application.dto.request.SignupRequestDto;
+import fete.be.domain.poster.persistence.PosterManager;
 import fete.be.global.util.Status;
 import fete.be.domain.ticket.persistence.Participant;
 import fete.be.domain.payment.persistence.Payment;
@@ -79,9 +80,8 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Poster> posters = new ArrayList<>();  // 유저가 등록한 프스터 리스트
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "poster_id")
-    private Poster managedPoster;  // 관리하고 있는 포스터 (현재는 1개만 가능)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<PosterManager> posterManagers = new ArrayList<>();  // 관리하고 있는 포스터들
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -191,14 +191,15 @@ public class Member {
         member.updatedAt = LocalDateTime.now();
     }
 
-    // 임시로 관리하고 있는 포스터 지정 메서드
-    public void setManagedPoster(Poster poster) {
-        this.managedPoster = poster;
+    // 임시로 관리하고 있는 포스터 매니저 리스트에 추가
+    public void addPosterManager(PosterManager posterManager) {
+        this.posterManagers.add(posterManager);
+        this.updatedAt = LocalDateTime.now();
     }
 
     // 관리하고 있는 포스터 초기화 메서드
-    public static void initManagedPoster(Member member) {
-        member.managedPoster = null;
+    public static void deletePosterManager(Member member, PosterManager posterManager) {
+        member.posterManagers.remove(posterManager);
         member.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/fete/be/domain/poster/application/PosterService.java
+++ b/src/main/java/fete/be/domain/poster/application/PosterService.java
@@ -381,7 +381,7 @@ public class PosterService {
         // 사용할 QClass
         QPoster poster = QPoster.poster;
         QEvent event = QEvent.event;
-        QMember managerMember = QMember.member;
+        QPosterManager posterManager = QPosterManager.posterManager;
 
         // 동적 쿼리
         BooleanBuilder builder = new BooleanBuilder();
@@ -399,9 +399,9 @@ public class PosterService {
         managerBuilder.or(poster.member.eq(member));
         managerBuilder.or(JPAExpressions
                 .selectOne()
-                .from(managerMember)
-                .where(managerMember.eq(member)
-                        .and(managerMember.managedPoster.eq(poster)))
+                .from(posterManager)
+                .where(posterManager.member.eq(member)
+                        .and(posterManager.poster.eq(poster)))
                 .exists());
         builder.and(managerBuilder);
 

--- a/src/main/java/fete/be/domain/poster/persistence/Poster.java
+++ b/src/main/java/fete/be/domain/poster/persistence/Poster.java
@@ -39,8 +39,8 @@ public class Poster {
     private String institution;  // 주최 팀 or 주최자 명
     @Column(name = "manager", nullable = false, length = 20)
     private String manager;  // 담당자 이름
-    @OneToMany(mappedBy = "managedPoster", cascade = CascadeType.PERSIST)
-    private List<Member> managers = new ArrayList<>();  // 임시 담당자 리스트
+    @OneToMany(mappedBy = "poster", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<PosterManager> posterManagers = new ArrayList<>();  // 임시 담당자 리스트
     @Column(name = "manager_contact", nullable = false, length = 20)
     private String managerContact;  // 담당자 연락처
     @Column(name = "manager_code")
@@ -153,9 +153,10 @@ public class Poster {
         poster.posterImages.clear();
 
         // 연관된 담당자들의 managedPoster 연결 해제
-        for (Member manager : poster.getManagers()) {
-            Member.initManagedPoster(manager);
+        for (PosterManager posterManager : poster.getPosterManagers()) {
+            Member.deletePosterManager(posterManager.getMember(), posterManager);
         }
+        poster.posterManagers.clear();
 
         LocalDateTime currentTime = LocalDateTime.now();
         poster.updatedAt = currentTime;
@@ -213,7 +214,7 @@ public class Poster {
     }
 
     // 임시 담당자 추가
-    public void addManager(Member manager) {
-        this.getManagers().add(manager);
+    public void addPosterManager(PosterManager posterManager) {
+        this.posterManagers.add(posterManager);
     }
 }

--- a/src/main/java/fete/be/domain/poster/persistence/PosterManager.java
+++ b/src/main/java/fete/be/domain/poster/persistence/PosterManager.java
@@ -1,0 +1,41 @@
+package fete.be.domain.poster.persistence;
+
+import fete.be.domain.member.persistence.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Slf4j
+public class PosterManager {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "poster_manager_id")
+    private Long posterManagerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poster_id")
+    private Poster poster;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;  // 수정일자
+
+
+    public static PosterManager createPosterManager(Member member, Poster poster) {
+        PosterManager posterManager = new PosterManager();
+
+        posterManager.member = member;
+        posterManager.poster = poster;
+        posterManager.updatedAt = LocalDateTime.now();
+
+        return posterManager;
+    }
+}

--- a/src/test/java/fete/be/domain/event/application/QRCodeServiceTest.java
+++ b/src/test/java/fete/be/domain/event/application/QRCodeServiceTest.java
@@ -1,0 +1,175 @@
+package fete.be.domain.event.application;
+
+import fete.be.domain.admin.application.dto.request.ApprovePostersRequest;
+import fete.be.domain.admin.application.dto.response.AccountDto;
+import fete.be.domain.event.application.dto.request.BuyTicketDto;
+import fete.be.domain.event.application.dto.request.BuyTicketRequest;
+import fete.be.domain.event.application.dto.request.ParticipantDto;
+import fete.be.domain.event.persistence.ArtistDto;
+import fete.be.domain.event.persistence.TicketInfoDto;
+import fete.be.domain.member.application.MemberService;
+import fete.be.domain.member.application.dto.request.SignupRequestDto;
+import fete.be.domain.member.persistence.Gender;
+import fete.be.domain.member.persistence.Member;
+import fete.be.domain.poster.application.PosterService;
+import fete.be.domain.poster.application.dto.request.EventDto;
+import fete.be.domain.poster.application.dto.request.Place;
+import fete.be.domain.poster.application.dto.request.WritePosterRequest;
+import fete.be.domain.poster.persistence.Poster;
+import fete.be.domain.ticket.persistence.Participant;
+import fete.be.domain.ticket.persistence.ParticipantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+class QRCodeServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private PosterService posterService;
+    @Autowired
+    private EventService eventService;
+    @Autowired
+    private QRCodeService qrCodeService;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @BeforeEach
+    void setUp() {
+        // SecurityContext에 인증정보 임의로 설정
+        String tempEmail = "kky6335@gmail.com";
+        String tempPassword = "hawon1234!";
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(tempEmail, tempPassword, List.of());
+        SecurityContext securityContext = new SecurityContextImpl(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        // 계정 생성
+        SignupRequestDto signupRequestDto = new SignupRequestDto("kky6335@gmail.com", "hawon1234!",
+                "www.profile.image.com", "강건영", "강건영입니다.", "2000-12-31", Gender.MALE, "01012345678");
+        memberService.signUp(signupRequestDto);
+    }
+
+    @DisplayName("QR 코드 티켓 인증")
+    @Test
+    void 성공_QR코드_티켓_인증() throws Exception {
+        // given #1 - 포스터 등록 후, 승인
+        WritePosterRequest writePosterRequest = generateWriteRequest();
+        Long posterId = posterService.writePoster(writePosterRequest);
+        ApprovePostersRequest request = new ApprovePostersRequest(List.of(posterId));
+        posterService.approvePosters(request);
+        Poster approvedPoster = posterService.findPosterByPosterId(posterId);
+
+        // given #2 - 무료 티켓 3장 구매
+        BuyTicketRequest buyTicketRequest = new BuyTicketRequest(
+                List.of(new BuyTicketDto("현장구매", 0, 3)),
+                null
+        );
+        List<String> qrCodes = eventService.buyTicket(approvedPoster.getPosterId(), buyTicketRequest);
+
+        // given #3 - 구입한 티켓 내역 조회
+        Member member = memberService.findMemberByEmail();
+        List<Participant> participants = participantRepository.findByMember(member);
+        Participant participant = participants.get(0);
+
+        // when - 발급된 QR 코드 인증 실행
+        ParticipantDto participantDto = new ParticipantDto(participant.getParticipantId(), member.getMemberId(),
+                approvedPoster.getEvent().getEventId(), participant.getPayment().getPaymentId());
+        Long usedParticipantId = qrCodeService.verifyQRCode(posterId, participantDto);
+        Optional<Participant> usedParticipant = participantRepository.findById(usedParticipantId);
+
+        // then - QR 코드가 사용 완료가 되어야 한다.
+        assertThat(usedParticipantId).isEqualTo(participant.getParticipantId());
+        assertThat(usedParticipant.get().getIsParticipated()).isTrue();
+    }
+
+    /**
+     * 포스터 등록 DTO 객체 생성
+     *
+     * @return WritePosterRequest
+     */
+    WritePosterRequest generateWriteRequest() {
+        // 장소 정보 생성
+        Place place = new Place(
+                "경기도 화성시 병점중앙로16 101동 106호",
+                "병점동",
+                "2층",
+                41.01234,
+                39.1234
+        );
+
+        // 티켓 정보 생성
+        List<TicketInfoDto> tickets = Arrays.asList(
+                new TicketInfoDto("얼리버드", "얼리버드는 티켓의 간단한 소개 내용입니다.", 10000, 10),
+                new TicketInfoDto("현장구매", "현장구매는 현장에서 구매하셔야 합니다.", 0, 15)
+        );
+
+        // 아티스트 정보 생성
+        List<ArtistDto> artists = Arrays.asList(
+                new ArtistDto("이하이", "https://info.url", ""),
+                new ArtistDto("악동뮤지션", "https://info.url", "")
+        );
+
+        // 계좌 정보 생성
+        AccountDto account = new AccountDto(
+                "농협",
+                "20708012341234",
+                "강건영"
+        );
+
+        // 이벤트 정보 생성
+        EventDto event = new EventDto(
+                "FETE의 첫 이벤트",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(3),
+                place,
+                false,
+                false,
+                false,
+                tickets,
+                "이벤트 관련 추가 설명입니다",
+                "몽환적인,잔잔한",
+                "POP,DISCO",
+                "http://www.instargram.kr",
+                artists,
+                account
+        );
+
+        // 포스터 등록 DTO 생성
+        WritePosterRequest request = new WritePosterRequest(
+                new String[]{
+                        "https://picsum.photos/230/530",
+                        "https://picsum.photos/300/500",
+                        "https://picsum.photos/1080/2080",
+                        "https://picsum.photos/1080/400"
+                },
+                "FETE",
+                "강건영",
+                "010-1234-5678",
+                event
+        );
+
+        return request;
+    }
+}

--- a/src/test/java/fete/be/domain/poster/application/PosterServiceTest.java
+++ b/src/test/java/fete/be/domain/poster/application/PosterServiceTest.java
@@ -4,6 +4,7 @@ import fete.be.domain.admin.application.dto.request.ApprovePostersRequest;
 import fete.be.domain.admin.application.dto.request.RejectPosterRequest;
 import fete.be.domain.admin.application.dto.response.AccountDto;
 import fete.be.domain.event.persistence.ArtistDto;
+import fete.be.domain.event.persistence.Genre;
 import fete.be.domain.event.persistence.TicketInfoDto;
 import fete.be.domain.member.application.MemberService;
 import fete.be.domain.member.application.dto.request.SignupRequestDto;
@@ -164,6 +165,7 @@ class PosterServiceTest {
                 // then
                 assertThat(poster.getPosterId()).isEqualTo(posterId);
                 assertThat(poster.getStatus()).isEqualTo(wantedStatus);
+                assertThat(poster.getGenres()).contains(Genre.D_AND_B.getKoreanValue());
             }
         }
     }
@@ -302,7 +304,7 @@ class PosterServiceTest {
                 tickets,
                 "이벤트 관련 추가 설명입니다",
                 "몽환적인,잔잔한",
-                "POP,DISCO",
+                "POP,DISCO,D&B",
                 "http://www.instargram.kr",
                 artists,
                 account


### PR DESCRIPTION
PosterManager
- 포스터별로 임시 담당자를 관리할 엔티티 생성

Member
- posterManagers 필드 추가
- addPosterManager: 임시 담당자 리스트에 담당자 한명 추가하는 메서드
- deletePosterManager: 임시 담당자 리스트에서 부분 삭제하는 메서드

Poster
- posterManagers 필드 추가
- deletePoster: 포스터 삭제 시, 해당 포스터를 담당하고 있던 담당자들의 연결 해제 코드 추가
- addPosterManager: 임시 담당자 리스트에 담당자 한명 추가하는 메서드

PosterServiceTest
- 성공_포스터_단건_조회: 장르 관련 검증 코드 추가
- generateWriteRequest: 테스트 DTO에 장르 추가

QRCodeServiceTest
- 성공_QR코드_티켓_인증