### PR TITLE
feat: 이미지 삭제 예외 처리 #38

### DIFF
--- a/src/main/java/fete/be/domain/image/application/ImageUploadService.java
+++ b/src/main/java/fete/be/domain/image/application/ImageUploadService.java
@@ -95,6 +95,9 @@ public class ImageUploadService {
      * 이미지 1장 삭제
      */
     public void deleteFile(String fileUrl) throws URISyntaxException {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            return;
+        }
         URI uri = new URI(fileUrl);
         String key = uri.getPath().substring(1);
 


### PR DESCRIPTION
ImageUploadService
- deleteFile: 삭제할 URL이 비어 있을 경우에 대한 방어 로직 추가