### PR TITLE
feat: 티켓 구매에 비관적 락 적용 #6

### DIFF
--- a/src/main/java/fete/be/domain/event/exception/NotFoundTicketException.java
+++ b/src/main/java/fete/be/domain/event/exception/NotFoundTicketException.java
@@ -1,0 +1,7 @@
+package fete.be.domain.event.exception;
+
+public class NotFoundTicketException extends RuntimeException {
+    public NotFoundTicketException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fete/be/domain/event/persistence/TicketRepository.java
+++ b/src/main/java/fete/be/domain/event/persistence/TicketRepository.java
@@ -1,0 +1,17 @@
+package fete.be.domain.event.persistence;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+    // 비관적 락
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from Ticket t where t.ticketId = :ticketId")
+    Optional<Ticket> findByIdForUpdate(@Param("ticketId") Long ticketId);
+}

--- a/src/main/java/fete/be/domain/event/web/EventController.java
+++ b/src/main/java/fete/be/domain/event/web/EventController.java
@@ -67,6 +67,8 @@ public class EventController {
             return new ApiResponse<>(ResponseMessage.EVENT_QR_FAILURE.getCode(), e.getMessage());
         } catch (InvalidTossResponseException e) {
             return new ApiResponse<>(ResponseMessage.INVALID_TOSS_PAYMENT_API_RESPONSE.getCode(), e.getMessage());
+        } catch (NotFoundTicketException e) {
+            return new ApiResponse<>(ResponseMessage.TICKET_NO_EXIST.getCode(), e.getMessage());
         } catch (Exception e) {
             return new ApiResponse<>(ResponseMessage.EVENT_QR_FAILURE.getCode(), e.getMessage());
         }


### PR DESCRIPTION
TicketRepository
- findByIdForUpdate: 비관적 락으로 티켓 조회

EventService
- buyTicket:
  - 판매된 티켓 개수를 업데이트 할 때 티켓 id 리스트를 넘기는 것으로 변경
  - 로직의 순서를 '티켓 수량 차감' -> '결제 승인 요청'으로 변경
  - 비관적 락 적용 이유: 티켓 수량에 대한 데이터 무결성 보장을 위해 적용
- updateSoldTicketCount: 비관적 락을 적용하여 티켓을 조회하도록 변경

EventController
- buyTicket: NotFoundTicketException 예외 처리 추가
- NotFoundTicketException: 티켓이 존재하지 않는 경우에 대한 Exception 추가