### PR TITLE
feat: 배너 조회 모델 분리 #151

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/fete/be/domain/banner/application/BannerQueryService.java
+++ b/src/main/java/fete/be/domain/banner/application/BannerQueryService.java
@@ -1,0 +1,20 @@
+package fete.be.domain.banner.application;
+
+import fete.be.domain.banner.application.dto.response.BannerDto;
+import fete.be.domain.banner.persistence.BannerQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BannerQueryService {
+
+    private final BannerQueryMapper bannerQueryMapper;
+
+    public List<BannerDto> getBanners() {
+        return bannerQueryMapper.findActiveBanners();
+    }
+
+}

--- a/src/main/java/fete/be/domain/banner/persistence/BannerQueryMapper.java
+++ b/src/main/java/fete/be/domain/banner/persistence/BannerQueryMapper.java
@@ -1,0 +1,11 @@
+package fete.be.domain.banner.persistence;
+
+import fete.be.domain.banner.application.dto.response.BannerDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface BannerQueryMapper {
+    List<BannerDto> findActiveBanners();
+}

--- a/src/main/java/fete/be/domain/banner/web/BannerController.java
+++ b/src/main/java/fete/be/domain/banner/web/BannerController.java
@@ -1,5 +1,6 @@
 package fete.be.domain.banner.web;
 
+import fete.be.domain.banner.application.BannerQueryService;
 import fete.be.domain.banner.application.BannerService;
 import fete.be.domain.banner.application.dto.response.BannerDto;
 import fete.be.domain.banner.application.dto.response.GetBannersResponse;
@@ -21,18 +22,37 @@ import java.util.List;
 public class BannerController {
 
     private final BannerService bannerService;
+    private final BannerQueryService bannerQueryService;
 
 
     /**
-     * 배너 전체 조회 API
+     * 배너 전체 조회 API (old) - JPA 방식
+     *
+     * @return ApiResponse<GetBannersResponse>
+     */
+    @GetMapping("/old")
+    public ApiResponse<GetBannersResponse> getBannersV1() {
+        try {
+            // 배너 전체 조회 (페이징 없이)
+            List<BannerDto> banners = bannerService.getBanners();
+            GetBannersResponse result = new GetBannersResponse(banners);
+
+            return new ApiResponse<>(ResponseMessage.BANNER_GET_BANNERS.getCode(), ResponseMessage.BANNER_GET_BANNERS.getMessage(), result);
+        } catch (IllegalArgumentException e) {
+            return new ApiResponse<>(ResponseMessage.BANNER_GET_BANNERS_FAIL.getCode(), e.getMessage());
+        }
+    }
+
+    /**
+     * 배너 전체 조회 API - MyBatis 방식
      *
      * @return ApiResponse<GetBannersResponse>
      */
     @GetMapping
-    public ApiResponse<GetBannersResponse> getBanners() {
+    public ApiResponse<GetBannersResponse> getBannerV2() {
         try {
             // 배너 전체 조회 (페이징 없이)
-            List<BannerDto> banners = bannerService.getBanners();
+            List<BannerDto> banners = bannerQueryService.getBanners();
             GetBannersResponse result = new GetBannersResponse(banners);
 
             return new ApiResponse<>(ResponseMessage.BANNER_GET_BANNERS.getCode(), ResponseMessage.BANNER_GET_BANNERS.getMessage(), result);

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -76,5 +76,9 @@ aws:
 firebase:
   service-account: ${FIREBASE_SERVICE_ACCOUNT}
 
+mybatis:
+  mapper-locations: classpath:mapper/**/*.xml
+  type-aliases-package: fete.be.domain
+
 logging.level:
   org.hibernate.SQL: info

--- a/src/main/resources/mapper/banner/BannerQueryMapper.xml
+++ b/src/main/resources/mapper/banner/BannerQueryMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="fete.be.domain.banner.persistence.BannerQueryMapper">
+    <select id="findActiveBanners" resultType="fete.be.domain.banner.application.dto.response.BannerDto">
+        SELECT b.banner_id AS bannerId,
+               b.title     AS title,
+               b.content   AS content,
+               b.image_url AS imageUrl,
+               p.poster_id AS posterId
+        FROM banner b
+                 JOIN poster p ON b.banner_id = p.banner_id
+        WHERE p.status IN ('ACTIVE', 'BANNER')
+    </select>
+</mapper>


### PR DESCRIPTION
MyBatis 환경설정
---
build.gradle
- mybatis 의존성 추가

application-docker.yml
- mybatis mapper 위치 설정

배너 조회 모델 분리
---
BannerController
- getBannerV2: MyBatis 방식 배너 전체 조회 API 추가

BannerQueryService
- 배너 조회용 서비스 클래스 생성
- getBanners: MyBatis로 배너 전체 조회

BannerQueryMapper
- 배너 조회용 Mapper 생성
- findActiveBanners: ACTIVE 상태 배너만 조회

BannerQueryMapper.xml
- findActiveBanners 쿼리문 추가