### PR TITLE
feat: 카테고리 조회 모델 분리 #153

### DIFF
--- a/src/main/java/fete/be/domain/admin/application/dto/response/SimplePosterDto.java
+++ b/src/main/java/fete/be/domain/admin/application/dto/response/SimplePosterDto.java
@@ -7,10 +7,12 @@ import fete.be.domain.poster.persistence.Poster;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class SimplePosterDto {

--- a/src/main/java/fete/be/domain/category/application/CategoryQueryService.java
+++ b/src/main/java/fete/be/domain/category/application/CategoryQueryService.java
@@ -1,0 +1,137 @@
+package fete.be.domain.category.application;
+
+import fete.be.domain.admin.application.dto.response.SimplePosterDto;
+import fete.be.domain.category.application.dto.response.CategoryDto;
+import fete.be.domain.category.application.dto.response.CategoryFlatDto;
+import fete.be.domain.category.application.dto.response.EndedCategoryResponse;
+import fete.be.domain.category.persistence.CategoryQueryMapper;
+import fete.be.domain.member.application.MemberService;
+import fete.be.domain.member.persistence.Member;
+import fete.be.domain.poster.persistence.PosterQueryMapper;
+import fete.be.global.util.Status;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class CategoryQueryService {
+
+    private final MemberService memberService;
+    private final PosterQueryMapper posterQueryMapper;
+    private final CategoryQueryMapper categoryQueryMapper;
+
+
+    public List<CategoryDto> getCategories() {
+        // 유저 조회
+        Member member = memberService.findMemberByEmail();
+
+        // 카테고리 관련 모든 데이터 조회
+        List<CategoryFlatDto> flatCategories = categoryQueryMapper.findActiveCategoryPosters(member.getMemberId());
+        Map<Long, CategoryDto> categories = new LinkedHashMap<>();
+
+        // 카테고리 그룹핑 진행
+        for (CategoryFlatDto dto : flatCategories) {
+            // 카테고리 생성 (중복 방지 로직)
+            categories.putIfAbsent(
+                    dto.getCategoryId(),
+                    new CategoryDto(dto.getCategoryId(), dto.getCategoryName(), new ArrayList<>())
+            );
+
+            // 카테고리에 맞게 포스터 추가
+            categories.get(dto.getCategoryId()).getSimplePosters().add(
+                    new SimplePosterDto(
+                            dto.getPosterId(),
+                            dto.getEventName(),
+                            dto.getPosterImage(),
+                            dto.getManager(),
+                            dto.getStartDate(),
+                            dto.getEndDate(),
+                            dto.getAddress(),
+                            dto.getSimpleAddress(),
+                            dto.getMoods(),
+                            dto.getGenres(),
+                            dto.getIsLike()
+                    )
+            );
+        }
+
+        return new ArrayList<>(categories.values());
+    }
+
+    public List<CategoryDto> getGuestCategories() {
+        // 카테고리 관련 모든 데이터 조회
+        List<CategoryFlatDto> flatCategories = categoryQueryMapper.findGuestActiveCategoryPosters();
+        Map<Long, CategoryDto> categories = new LinkedHashMap<>();
+
+        // 카테고리 그룹핑 진행
+        for (CategoryFlatDto dto : flatCategories) {
+            // 카테고리 생성 (중복 방지 로직)
+            categories.putIfAbsent(
+                    dto.getCategoryId(),
+                    new CategoryDto(dto.getCategoryId(), dto.getCategoryName(), new ArrayList<>())
+            );
+
+            // 카테고리에 맞게 포스터 추가
+            categories.get(dto.getCategoryId()).getSimplePosters().add(
+                    new SimplePosterDto(
+                            dto.getPosterId(),
+                            dto.getEventName(),
+                            dto.getPosterImage(),
+                            dto.getManager(),
+                            dto.getStartDate(),
+                            dto.getEndDate(),
+                            dto.getAddress(),
+                            dto.getSimpleAddress(),
+                            dto.getMoods(),
+                            dto.getGenres(),
+                            dto.getIsLike()
+                    )
+            );
+        }
+
+        return new ArrayList<>(categories.values());
+    }
+
+    public EndedCategoryResponse getEndedCategory() {
+        // 유저 조회
+        Member member = memberService.findMemberByEmail();
+
+        // 날짜 계산
+        LocalDateTime today = LocalDate.now().atTime(0, 0, 0);
+        LocalDateTime tomorrow = today.plusDays(1);
+        LocalDateTime sevenDaysAgo = today.minusDays(7);
+
+        // 오늘 날짜 포함 7일 이내로 종료된 포스터 조회
+        List<SimplePosterDto> endedPosters = posterQueryMapper.findEndedPosters(
+                member.getMemberId(),
+                sevenDaysAgo,
+                tomorrow
+        );
+
+        return new EndedCategoryResponse("종료된 이벤트", endedPosters);
+    }
+
+    public EndedCategoryResponse getGuestEndedCategory() {
+        // 날짜 계산
+        LocalDateTime today = LocalDate.now().atTime(0, 0, 0);
+        LocalDateTime tomorrow = today.plusDays(1);
+        LocalDateTime sevenDaysAgo = today.minusDays(7);
+
+        // 오늘 날짜 포함 7일 이내로 종료된 포스터 조회
+        List<SimplePosterDto> endedPosters = posterQueryMapper.findGuestEndedPosters(sevenDaysAgo, tomorrow);
+
+        return new EndedCategoryResponse("종료된 이벤트", endedPosters);
+    }
+}

--- a/src/main/java/fete/be/domain/category/application/dto/response/CategoryFlatDto.java
+++ b/src/main/java/fete/be/domain/category/application/dto/response/CategoryFlatDto.java
@@ -1,0 +1,30 @@
+package fete.be.domain.category.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CategoryFlatDto {
+    private Long categoryId;
+    private String categoryName;
+
+    private Long posterId;  // 포스터 아이디
+    private String eventName;  // 이벤트 이름
+    private String posterImage;  // 대표 이미지 1장
+    private String manager;  // 담당자 이름
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime startDate;  // 이벤트 시작일
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime endDate;  // 이벤트 종료일
+    private String address;  // 주소
+    private String simpleAddress;  // 간단 주소
+    private String moods;  // 이벤트 무드
+    private String genres;  // 장르
+    private Boolean isLike;  // 사용자의 관심 등록 상태
+}

--- a/src/main/java/fete/be/domain/category/persistence/CategoryQueryMapper.java
+++ b/src/main/java/fete/be/domain/category/persistence/CategoryQueryMapper.java
@@ -1,0 +1,14 @@
+package fete.be.domain.category.persistence;
+
+import fete.be.domain.category.application.dto.response.CategoryFlatDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CategoryQueryMapper {
+
+    List<CategoryFlatDto> findActiveCategoryPosters(@Param("memberId") Long memberId);
+    List<CategoryFlatDto> findGuestActiveCategoryPosters();
+}

--- a/src/main/java/fete/be/domain/category/web/CategoryController.java
+++ b/src/main/java/fete/be/domain/category/web/CategoryController.java
@@ -1,5 +1,6 @@
 package fete.be.domain.category.web;
 
+import fete.be.domain.category.application.CategoryQueryService;
 import fete.be.domain.category.application.CategoryService;
 import fete.be.domain.category.application.dto.response.CategoryDto;
 import fete.be.domain.category.application.dto.response.EndedCategoryResponse;
@@ -23,15 +24,16 @@ import java.util.List;
 public class CategoryController {
 
     private final CategoryService categoryService;
+    private final CategoryQueryService categoryQueryService;
 
 
     /**
-     * 카테고리 전체 조회 API
+     * 카테고리 전체 조회 API - JPA
      *
      * @return ApiResponse<GetCategoriesResponse>
      */
-    @GetMapping
-    public ApiResponse<GetCategoriesResponse> getCategories() {
+    @GetMapping("/a1")
+    public ApiResponse<GetCategoriesResponse> getCategoriesV1() {
         try {
             // 카테고리 전체 조회 (페이징 없이)
             List<CategoryDto> categories = categoryService.getCategories();
@@ -49,13 +51,13 @@ public class CategoryController {
 
 
     /**
-     * 종료된 이벤트 카테고리 조회 API
+     * 종료된 이벤트 카테고리 조회 API - JPA
      * - 7일 이내로 종료된 프스터만 조회
      *
      * @return ApiResponse<EndedCategoryResponse>
      */
-    @GetMapping("/end")
-    public ApiResponse<EndedCategoryResponse> getEndedCategory() {
+    @GetMapping("/b1")
+    public ApiResponse<EndedCategoryResponse> getEndedCategoryV1() {
         try {
             // 종료된 이벤트 카테고리 조회 (페이징 X)
             EndedCategoryResponse result = categoryService.getEndedCategory();
@@ -64,6 +66,27 @@ public class CategoryController {
         } catch (GuestUserException e) {
             // 게스트용 종료된 이벤트 카테고리 조회 (페이징 X)
             EndedCategoryResponse result = categoryService.getGuestEndedCategory();
+
+            return new ApiResponse<>(ResponseMessage.GET_END_CATEGORY.getCode(), ResponseMessage.GET_END_CATEGORY.getMessage(), result);
+        }
+    }
+
+    /**
+     * 종료된 이벤트 카테고리 조회 API - MyBatis
+     * - 7일 이내로 종료된 프스터만 조회
+     *
+     * @return ApiResponse<EndedCategoryResponse>
+     */
+    @GetMapping("/end")
+    public ApiResponse<EndedCategoryResponse> getEndedCategoryV2() {
+        try {
+            // 종료된 이벤트 카테고리 조회 (페이징 X)
+            EndedCategoryResponse result = categoryQueryService.getEndedCategory();
+
+            return new ApiResponse<>(ResponseMessage.GET_END_CATEGORY.getCode(), ResponseMessage.GET_END_CATEGORY.getMessage(), result);
+        } catch (GuestUserException e) {
+            // 게스트용 종료된 이벤트 카테고리 조회 (페이징 X)
+            EndedCategoryResponse result = categoryQueryService.getGuestEndedCategory();
 
             return new ApiResponse<>(ResponseMessage.GET_END_CATEGORY.getCode(), ResponseMessage.GET_END_CATEGORY.getMessage(), result);
         }

--- a/src/main/java/fete/be/domain/category/web/CategoryController.java
+++ b/src/main/java/fete/be/domain/category/web/CategoryController.java
@@ -49,6 +49,28 @@ public class CategoryController {
         }
     }
 
+    /**
+     * 카테고리 전체 조회 API - MyBatis
+     *
+     * @return ApiResponse<GetCategoriesResponse>
+     */
+    @GetMapping
+    public ApiResponse<GetCategoriesResponse> getCategoriesV2() {
+        try {
+            // 카테고리 전체 조회 (페이징 없이)
+            List<CategoryDto> categories = categoryQueryService.getCategories();
+            GetCategoriesResponse result = new GetCategoriesResponse(categories);
+
+            return new ApiResponse<>(ResponseMessage.CATEGORY_GET_CATEGORIES.getCode(), ResponseMessage.CATEGORY_GET_CATEGORIES.getMessage(), result);
+        } catch (GuestUserException e) {
+            // 게스트용 카테고리 전체 조회 (페이징 없이)
+            List<CategoryDto> categories = categoryQueryService.getGuestCategories();
+            GetCategoriesResponse result = new GetCategoriesResponse(categories);
+
+            return new ApiResponse<>(ResponseMessage.CATEGORY_GET_CATEGORIES.getCode(), ResponseMessage.CATEGORY_GET_CATEGORIES.getMessage(), result);
+        }
+    }
+
 
     /**
      * 종료된 이벤트 카테고리 조회 API - JPA

--- a/src/main/java/fete/be/domain/poster/persistence/PosterQueryMapper.java
+++ b/src/main/java/fete/be/domain/poster/persistence/PosterQueryMapper.java
@@ -1,0 +1,23 @@
+package fete.be.domain.poster.persistence;
+
+import fete.be.domain.admin.application.dto.response.SimplePosterDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface PosterQueryMapper {
+
+    List<SimplePosterDto> findEndedPosters(
+            @Param("memberId") Long memberId,
+            @Param("sevenDaysAgo")LocalDateTime sevenDaysAgo,
+            @Param("tomorrow") LocalDateTime tomorrow
+    );
+
+    List<SimplePosterDto> findGuestEndedPosters(
+            @Param("sevenDaysAgo")LocalDateTime sevenDaysAgo,
+            @Param("tomorrow") LocalDateTime tomorrow
+    );
+}

--- a/src/main/resources/mapper/category/CategoryQueryMapper.xml
+++ b/src/main/resources/mapper/category/CategoryQueryMapper.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="fete.be.domain.category.persistence.CategoryQueryMapper">
+    <select id="findActiveCategoryPosters" resultType="fete.be.domain.category.application.dto.response.CategoryFlatDto">
+        SELECT
+            c.category_id AS categoryId,
+            c.category_name AS categoryName,
+
+            p.poster_id AS posterId,
+            e.event_name AS eventName,
+            COALESCE(pi.image_url, '') AS posterImage,
+            p.manager AS manager,
+            e.start_date AS startDate,
+            e.end_date AS endDate,
+            e.address AS address,
+            e.simple_address AS simpleAddress,
+            e.moods AS moods,
+            e.genres AS genres,
+
+            CASE WHEN pl.poster_id IS NOT NULL THEN true ELSE false END AS isLike
+
+        FROM category c
+                 JOIN poster p ON p.category_id = c.category_id
+                 JOIN event e ON e.poster_id = p.poster_id
+
+            -- 대표 이미지 1개
+                 LEFT JOIN (
+            SELECT pi1.poster_id, pi1.image_url
+            FROM poster_image pi1
+            WHERE pi1.poster_image_id = (
+                SELECT pi2.poster_image_id
+                FROM poster_image pi2
+                WHERE pi2.poster_id = pi1.poster_id
+                ORDER BY pi2.poster_image_id ASC
+                LIMIT 1
+        )
+            ) pi ON p.poster_id = pi.poster_id
+
+            -- 좋아요 여부
+            LEFT JOIN poster_like pl
+            ON pl.poster_id = p.poster_id
+            AND pl.member_id = #{memberId}
+
+        WHERE p.status = 'ACTIVE'
+    </select>
+
+    <select id="findGuestActiveCategoryPosters" resultType="fete.be.domain.category.application.dto.response.CategoryFlatDto">
+        SELECT
+            c.category_id AS categoryId,
+            c.category_name AS categoryName,
+
+            p.poster_id AS posterId,
+            e.event_name AS eventName,
+            COALESCE(pi.image_url, '') AS posterImage,
+            p.manager AS manager,
+            e.start_date AS startDate,
+            e.end_date AS endDate,
+            e.address AS address,
+            e.simple_address AS simpleAddress,
+            e.moods AS moods,
+            e.genres AS genres,
+            false AS isLike
+
+        FROM category c
+                 JOIN poster p ON p.category_id = c.category_id
+                 JOIN event e ON e.poster_id = p.poster_id
+
+            -- 대표 이미지 1개
+                 LEFT JOIN (
+            SELECT pi1.poster_id, pi1.image_url
+            FROM poster_image pi1
+            WHERE pi1.poster_image_id = (
+                SELECT pi2.poster_image_id
+                FROM poster_image pi2
+                WHERE pi2.poster_id = pi1.poster_id
+                ORDER BY pi2.poster_image_id ASC
+                LIMIT 1
+        )
+            ) pi ON p.poster_id = pi.poster_id
+
+        WHERE p.status = 'ACTIVE'
+    </select>
+</mapper>

--- a/src/main/resources/mapper/poster/PosterQueryMapper.xml
+++ b/src/main/resources/mapper/poster/PosterQueryMapper.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="fete.be.domain.poster.persistence.PosterQueryMapper">
+    <select id="findEndedPosters" resultType="fete.be.domain.admin.application.dto.response.SimplePosterDto">
+        SELECT
+            p.poster_id AS posterId,
+            e.event_name AS eventName,
+            COALESCE(pi.image_url, '') AS posterImage,
+            p.manager AS manager,
+            e.start_date AS startDate,
+            e.end_date AS endDate,
+            e.address AS address,
+            e.simple_address AS simpleAddress,
+            e.moods AS moods,
+            e.genres AS genres,
+            CASE WHEN pl.poster_id IS NOT NULL THEN true ELSE false END AS isLike
+        FROM poster p
+        JOIN event e ON e.poster_id = p.poster_id
+
+        -- 대표 이미지 1개
+        LEFT JOIN (
+            SELECT pi1.poster_id, pi1.image_url
+            FROM poster_image pi1
+            WHERE pi1.poster_image_id = (
+                SELECT pi2.poster_image_id
+                FROM poster_image pi2
+                WHERE pi2.poster_id = pi1.poster_id
+                ORDER BY pi2.poster_image_id ASC
+                LIMIT 1
+            )
+        ) pi ON p.poster_id = pi.poster_id
+
+        -- 좋아요 여부
+        LEFT JOIN poster_like pl
+            ON pl.poster_id = p.poster_id
+            AND pl.member_id = #{memberId}
+
+        WHERE p.status = 'END'
+            AND e.end_date >= #{sevenDaysAgo}
+            AND e.end_date &lt; #{tomorrow}
+    </select>
+
+    <select id="findGuestEndedPosters" resultType="fete.be.domain.admin.application.dto.response.SimplePosterDto">
+        SELECT
+            p.poster_id AS posterId,
+            e.event_name AS eventName,
+            COALESCE(pi.image_url, '') AS posterImage,
+            p.manager AS manager,
+            e.start_date AS startDate,
+            e.end_date AS endDate,
+            e.address AS address,
+            e.simple_address AS simpleAddress,
+            e.moods AS moods,
+            e.genres AS genres,
+            false AS isLike
+        FROM poster p
+        JOIN event e ON e.poster_id = p.poster_id
+
+        -- 대표 이미지 1개
+        LEFT JOIN (
+            SELECT pi1.poster_id, pi1.image_url
+            FROM poster_image pi1
+            WHERE pi1.poster_image_id = (
+                SELECT pi2.poster_image_id
+                FROM poster_image pi2
+                WHERE pi2.poster_id = pi1.poster_id
+                ORDER BY pi2.poster_image_id ASC
+                LIMIT 1
+            )
+        ) pi ON p.poster_id = pi.poster_id
+
+        WHERE p.status = 'END'
+        AND e.end_date >= #{sevenDaysAgo}
+        AND e.end_date &lt; #{tomorrow}
+    </select>
+</mapper>


### PR DESCRIPTION
종료된 이벤트 카테고리 조회 모델 분리
---
CategoryController
- getEndedCategoryV2: 종료된 이벤트 카테고리 MyBatis로 조회

PosterQueryMapper
- 종료된 이벤트 카테고리 조회용 Mapper 생성
- findEndedPosters: END 상태 포스터 조회
- findGuestEndedPosters: 게스트용 END 상태 포스터 조회

PosterQueryMapper.xml
- findEndedPosters, findGuestEndedPosters 쿼리문 추가

SimplePosterDto
- MyBatis 바인딩을 위한 setter 추가

카테고리 전체 조회 모델 분리
---
CategoryController
- getCategoriesV2: 카테고리 전체를 MyBatis로 조회

CategoryQueryMapper
- 카테고리 전체 조회용 Mapper 생성
- findActiveCategoryPosters: ACTIVE 상태의 카테고리 전체 조회
- findGuestActiveCategoryPosters: 게스트용 ACTIVE 상태의 카테고리 전체 조회

CategoryQueryMapper.xml
- findActiveCategoryPosters, findGuestActiveCategoryPosters 쿼리문 추가

CategoryQueryService
- 카테고리 조회용 서비스 클래스 생성
- getCategories: 전체 카테고리 조회
- getGuestCategories: 게스트용 전체 카테고리 조회
- getEndedCategory: 종료된 이벤트 카테고리 조회
- getGuestEndedCategory: 게스트용 종료된 이벤트 카테고리 조회

CategoryFlatDto
- MyBatis용 Flat Dto 생성